### PR TITLE
Add possibility to execute publish strategy after data is assigned to the element

### DIFF
--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -22,6 +22,7 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\MappingConfigurationFactory;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Bundle\DataImporterBundle\PimcoreDataImporterBundle;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
+use Pimcore\Bundle\DataImporterBundle\Resolver\Publish\PostUpdatePublishStrategyInterface;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Resolver;
 use Pimcore\Bundle\DataImporterBundle\Resolver\ResolverFactory;
 use Pimcore\Bundle\DataImporterBundle\Settings\ConfigurationPreparationService;
@@ -176,6 +177,11 @@ class ImportProcessingService
 
                 $dataTarget = $mappingConfiguration->getDataTarget();
                 $dataTarget->assignData($element, $data);
+            }
+
+            $postUpdateUpdateStrategy = $resolver->getPublishingStrategy();
+            if($postUpdateUpdateStrategy instanceof PostUpdatePublishStrategyInterface) {
+                $postUpdateUpdateStrategy->postUpdateUpdatePublishState($element, $importDataRow);
             }
 
             $element->save();

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -180,7 +180,7 @@ class ImportProcessingService
             }
 
             $postUpdateUpdateStrategy = $resolver->getPublishingStrategy();
-            if($postUpdateUpdateStrategy instanceof PostUpdatePublishStrategyInterface) {
+            if ($postUpdateUpdateStrategy instanceof PostUpdatePublishStrategyInterface) {
                 $postUpdateUpdateStrategy->postUpdateUpdatePublishState($element, $importDataRow);
             }
 

--- a/src/Resolver/Publish/PostUpdatePublishStrategyInterface.php
+++ b/src/Resolver/Publish/PostUpdatePublishStrategyInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Resolver\Publish;
+
+use Pimcore\Model\Element\ElementInterface;
+
+interface PostUpdatePublishStrategyInterface extends PublishStrategyInterface
+{
+    /**
+     * Set publish state of element based on input data. Will be called after all import data is assigned to the element
+     *
+     * @param ElementInterface $element
+     * @param array $inputData
+     *
+     * @return ElementInterface
+     */
+    public function postUpdateUpdatePublishState(ElementInterface $element, array $inputData): ElementInterface;
+}


### PR DESCRIPTION
by implementing the additional interface `PostUpdatePublishStrategyInterface` with your publish strategy, where you can define your custom logic...

like for example: 

```php 
class AlwaysPublishStrategy implements PostUpdatePublishStrategyInterface
{
    public function setSettings(array $settings): void
    {
        //nothing to do
    }

    public function updatePublishState(ElementInterface $element, bool $justCreated, array $inputData): ElementInterface
    {
        $element->setPublished(true);

        return $element;
    }

    public function postUpdateUpdatePublishState(ElementInterface $element, array $inputData): ElementInterface
    {
        //nothing to do
    }
}

``` 
