### PR TITLE
Change defaults for overwrite | Checking unpublished objects in relations for existing data

### DIFF
--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -59,7 +59,6 @@ class Direct implements DataTargetInterface
         //note - cannot be replaced with ?? as $settings['writeIfSourceIsEmpty'] can be false on purpose
         $this->writeIfSourceIsEmpty = isset($settings['writeIfSourceIsEmpty']) ? $settings['writeIfSourceIsEmpty'] : true;
         $this->writeIfTargetIsNotEmpty = isset($settings['writeIfTargetIsNotEmpty']) ? $settings['writeIfTargetIsNotEmpty'] : true;
-       
     }
 
     /**

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -112,11 +112,12 @@ class Direct implements DataTargetInterface
      * @param $newData
      * @param $valueContainer
      * @param $getter
+     *
      * @return bool
      */
     protected function checkAssignData($newData, $valueContainer, $getter)
     {
-        if($this->writeIfTargetIsNotEmpty === true && $this->writeIfSourceIsEmpty === true) {
+        if ($this->writeIfTargetIsNotEmpty === true && $this->writeIfSourceIsEmpty === true) {
             return true;
         }
 
@@ -124,7 +125,6 @@ class Direct implements DataTargetInterface
         DataObject::setHideUnpublished(false);
         $currentData = $valueContainer->$getter($this->language);
         DataObject::setHideUnpublished($hideUnpublished);
-
 
         if (!empty($currentData) && $this->writeIfTargetIsNotEmpty === false) {
             return false;

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -112,7 +112,7 @@ class Direct implements DataTargetInterface
             $setter = 'set' . ucfirst($setterParts[2]);
             $getter = 'get' . ucfirst($setterParts[2]);
             DataObject::setHideUnpublished(false);
-            $currentData = $element->$getter($this->language);
+            $currentData = $brick->$getter($this->language);
             DataObject::setHideUnpublished($hideUnpublished);
             if (!$this->checkAssignData($data, $currentData)) {
                 return;

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -56,17 +56,9 @@ class Direct implements DataTargetInterface
         $this->fieldName = $settings['fieldName'];
         $this->language = $settings['language'] ?? null;
 
-        if (isset($settings['writeIfSourceIsEmpty'])) {
-            $this->writeIfSourceIsEmpty = $settings['writeIfSourceIsEmpty'];
-        } else {
-            $this->writeIfSourceIsEmpty = false;
-        }
-
-        if (isset($settings['writeIfTargetIsNotEmpty'])) {
-            $this->writeIfTargetIsNotEmpty = $settings['writeIfTargetIsNotEmpty'];
-        } else {
-            $this->writeIfTargetIsNotEmpty = false;
-        }
+        $this->writeIfSourceIsEmpty = $settings['writeIfSourceIsEmpty'] ?? false;
+        $this->writeIfTargetIsNotEmpty = $settings['writeIfTargetIsNotEmpty' ?? false;
+       
     }
 
     /**

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -35,12 +35,12 @@ class Direct implements DataTargetInterface
     /**
      * @var bool
      */
-    protected $writeIfSourceIsEmpty = false;
+    protected $writeIfSourceIsEmpty;
 
     /**
      * @var bool
      */
-    protected $writeIfTargetIsNotEmpty = false;
+    protected $writeIfTargetIsNotEmpty;
 
     /**
      * @param array $settings
@@ -56,8 +56,9 @@ class Direct implements DataTargetInterface
         $this->fieldName = $settings['fieldName'];
         $this->language = $settings['language'] ?? null;
 
-        $this->writeIfSourceIsEmpty = $settings['writeIfSourceIsEmpty'] ?? false;
-        $this->writeIfTargetIsNotEmpty = $settings['writeIfTargetIsNotEmpty' ?? false;
+        //note - cannot be replaced with ?? as $settings['writeIfSourceIsEmpty'] can be false on purpose
+        $this->writeIfSourceIsEmpty = isset($settings['writeIfSourceIsEmpty']) ? $settings['writeIfSourceIsEmpty'] : true;
+        $this->writeIfTargetIsNotEmpty = isset($settings['writeIfTargetIsNotEmpty']) ? $settings['writeIfTargetIsNotEmpty'] : true;
        
     }
 

--- a/src/Resources/public/js/pimcore/configuration/components/mapping/datatarget/direct.js
+++ b/src/Resources/public/js/pimcore/configuration/components/mapping/datatarget/direct.js
@@ -86,7 +86,7 @@ pimcore.plugin.pimcoreDataImporterBundle.configuration.components.mapping.datata
             const writeIfTargetIsNotEmpty = Ext.create('Ext.form.Checkbox', {
                 boxLabel: t('plugin_pimcore_datahub_data_importer_configpanel_dataTarget.type_direct_write_settings_ifTargetIsNotEmpty'),
                 name: this.dataNamePrefix + 'writeIfTargetIsNotEmpty',
-                value: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? this.data.writeIfTargetIsNotEmpty : false,
+                value: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? this.data.writeIfTargetIsNotEmpty : true,
                 inputValue: true,
                 listeners: {
                     change: function (checkbox, value) {
@@ -103,8 +103,8 @@ pimcore.plugin.pimcoreDataImporterBundle.configuration.components.mapping.datata
             const writeIfSourceIsEmpty = Ext.create('Ext.form.Checkbox', {
                 boxLabel: t('plugin_pimcore_datahub_data_importer_configpanel_dataTarget.type_direct_write_settings_ifSourceIsEmpty'),
                 name: this.dataNamePrefix + 'writeIfSourceIsEmpty',
-                value: this.data.hasOwnProperty('writeIfSourceIsEmpty') ? this.data.writeIfSourceIsEmpty : false,
-                disabled: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? !this.data.writeIfTargetIsNotEmpty : true,
+                value: this.data.hasOwnProperty('writeIfSourceIsEmpty') ? this.data.writeIfSourceIsEmpty : true,
+                disabled: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? !this.data.writeIfTargetIsNotEmpty : false,
                 inputValue: true
             });
 

--- a/src/Resources/public/js/pimcore/configuration/components/mapping/datatarget/direct.js
+++ b/src/Resources/public/js/pimcore/configuration/components/mapping/datatarget/direct.js
@@ -88,13 +88,15 @@ pimcore.plugin.pimcoreDataImporterBundle.configuration.components.mapping.datata
                 name: this.dataNamePrefix + 'writeIfTargetIsNotEmpty',
                 value: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? this.data.writeIfTargetIsNotEmpty : true,
                 inputValue: true,
+                uncheckedValue: false,
                 listeners: {
                     change: function (checkbox, value) {
                         if (value) {
-                            writeIfSourceIsEmpty.enable();
+                            writeIfSourceIsEmpty.setReadOnly(false);
+                            writeIfSourceIsEmpty.setValue(true);
                         } else {
                             writeIfSourceIsEmpty.setValue(false);
-                            writeIfSourceIsEmpty.disable();
+                            writeIfSourceIsEmpty.setReadOnly(true);
                         }
                     }
                 }
@@ -104,10 +106,11 @@ pimcore.plugin.pimcoreDataImporterBundle.configuration.components.mapping.datata
                 boxLabel: t('plugin_pimcore_datahub_data_importer_configpanel_dataTarget.type_direct_write_settings_ifSourceIsEmpty'),
                 name: this.dataNamePrefix + 'writeIfSourceIsEmpty',
                 value: this.data.hasOwnProperty('writeIfSourceIsEmpty') ? this.data.writeIfSourceIsEmpty : true,
-                disabled: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? !this.data.writeIfTargetIsNotEmpty : false,
+                uncheckedValue: false,
+                readOnly: this.data.hasOwnProperty('writeIfTargetIsNotEmpty') ? !this.data.writeIfTargetIsNotEmpty : false,
                 inputValue: true
             });
-
+            
             this.form = Ext.create('DataHub.DataImporter.StructuredValueForm', {
                 defaults: {
                     labelWidth: 120,


### PR DESCRIPTION
Should resolve issue #97 
* Change defaults for overwrite
* Checking unpublished objects in relations for existing data
* Only loads existing data when necessary
