### PR TITLE
Make sure that first execution of cron execution is in future

### DIFF
--- a/src/EventListener/ConfigurationEventSubscriber.php
+++ b/src/EventListener/ConfigurationEventSubscriber.php
@@ -115,7 +115,8 @@ class ConfigurationEventSubscriber implements EventSubscriberInterfaceAlias
         }
     }
 
-    public function postSave(GenericEvent $event) {
+    public function postSave(GenericEvent $event)
+    {
         /**
          * @var $config Configuration
          */

--- a/src/EventListener/ConfigurationEventSubscriber.php
+++ b/src/EventListener/ConfigurationEventSubscriber.php
@@ -72,7 +72,8 @@ class ConfigurationEventSubscriber implements EventSubscriberInterfaceAlias
     public static function getSubscribedEvents()
     {
         return [
-            ConfigurationEvents::CONFIGURATION_POST_DELETE => 'postDelete'
+            ConfigurationEvents::CONFIGURATION_POST_DELETE => 'postDelete',
+            ConfigurationEvents::CONFIGURATION_POST_SAVE => 'postSave'
         ];
     }
 
@@ -111,6 +112,17 @@ class ConfigurationEventSubscriber implements EventSubscriberInterfaceAlias
 
             //cleanup cron execution
             $this->cronExecutionService->cleanup($config->getName());
+        }
+    }
+
+    public function postSave(GenericEvent $event) {
+        /**
+         * @var $config Configuration
+         */
+        $config = $event->getSubject();
+
+        if ($config->getType() === 'dataImporterDataObject') {
+            $this->cronExecutionService->initExecution($config->getName());
         }
     }
 }

--- a/src/Processing/Cron/CronExecutionService.php
+++ b/src/Processing/Cron/CronExecutionService.php
@@ -101,17 +101,16 @@ class CronExecutionService
         }
     }
 
-    public function initExecution(string $configName) {
-
+    public function initExecution(string $configName)
+    {
         $timestamp = $this->getDb()->fetchOne(
                 sprintf('SELECT lastExecutionDate FROM %s WHERE configName = ?', self::EXECUTION_STORAGE_TABLE_NAME),
                 [$configName]
             );
 
-        if($timestamp === false) {
+        if ($timestamp === false) {
             $this->updateExecutionTimestamp($configName, new \DateTime());
         }
-
     }
 
     public function cleanup(string $configName)

--- a/src/Processing/Cron/CronExecutionService.php
+++ b/src/Processing/Cron/CronExecutionService.php
@@ -101,6 +101,19 @@ class CronExecutionService
         }
     }
 
+    public function initExecution(string $configName) {
+
+        $timestamp = $this->getDb()->fetchOne(
+                sprintf('SELECT lastExecutionDate FROM %s WHERE configName = ?', self::EXECUTION_STORAGE_TABLE_NAME),
+                [$configName]
+            ) ?? time();
+
+        if($timestamp === null ) {
+            $this->updateExecutionTimestamp($configName, new \DateTime());
+        }
+
+    }
+
     public function cleanup(string $configName)
     {
         try {

--- a/src/Processing/Cron/CronExecutionService.php
+++ b/src/Processing/Cron/CronExecutionService.php
@@ -106,9 +106,9 @@ class CronExecutionService
         $timestamp = $this->getDb()->fetchOne(
                 sprintf('SELECT lastExecutionDate FROM %s WHERE configName = ?', self::EXECUTION_STORAGE_TABLE_NAME),
                 [$configName]
-            ) ?? time();
+            );
 
-        if($timestamp === null ) {
+        if($timestamp === false) {
             $this->updateExecutionTimestamp($configName, new \DateTime());
         }
 


### PR DESCRIPTION
init last execution timestamp for configuration

- [x] probably only set value when cron definition is configured the first time? 
- [x] and unset the last execution timestamp when cron definition is unset again?