### PR TITLE
fix: change ElementInterface | null to ?ElementInterface

### DIFF
--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -174,7 +174,7 @@ class Resolver
      *
      * @return ElementInterface | null
      */
-    public function loadOrCreateAndPrepareElement(array $inputData, bool $createNew = true): ElementInterface | null
+    public function loadOrCreateAndPrepareElement(array $inputData, bool $createNew = true): ?ElementInterface
     {
         $element = $this->loadElement($inputData);
 


### PR DESCRIPTION
The syntax "ElementInterface | null" is only supported since PHP 8 and breaks this bundle in Pimcore 6. Changed to ?ElementInterface.