### PR TITLE
Can't save Data Objects Importer Configuration on Pimcore 6.9.x and data-importer 1.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   },
   "require": {
     "php": ">=7.4",
-    "pimcore/pimcore": "^6.9 || ^10.0",
+    "pimcore/pimcore": "^10.2",
     "pimcore/data-hub": "^0.7 || ^1.0",
     "phpoffice/phpspreadsheet": "^1.1",
     "dragonmantank/cron-expression": "^3.1",

--- a/doc/01_Installation.md
+++ b/doc/01_Installation.md
@@ -5,8 +5,19 @@ to be installed first.
 
 To install Pimcore Data Importer use following commands: 
 
+For Pimcore version >= 10.2:
 ```bash
 composer require pimcore/data-importer
+```
+
+For Pimcore version < 10.2:
+```bash
+composer require pimcore/data-importer:~1.2.2
+```
+
+To enable the bundle:
+
+```bash
 ./bin/console pimcore:bundle:enable PimcoreDataImporterBundle
 ```
 


### PR DESCRIPTION
closes #125 