### PR TITLE
Set classification store data in importing elements

### DIFF
--- a/src/Mapping/DataTarget/Classificationstore.php
+++ b/src/Mapping/DataTarget/Classificationstore.php
@@ -60,11 +60,14 @@ class Classificationstore implements DataTargetInterface
     public function assignData(ElementInterface $element, $data)
     {
         $getter = 'get' . ucfirst($this->fieldName);
+        $setter = 'set' . ucfirst($this->fieldName);
         $classificationStore = $element->$getter();
 
         if ($classificationStore instanceof \Pimcore\Model\DataObject\Classificationstore) {
             $classificationStore->setLocalizedKeyValue($this->groupId, $this->keyId, $data, $this->language);
             $classificationStore->setActiveGroups($classificationStore->getActiveGroups() + [$this->groupId => true]);
+
+            $element->$setter($classificationStore, $this->language);
         } else {
             throw new InvalidConfigurationException('Field ' . $this->fieldName . ' is not a classification store.');
         }

--- a/src/Mapping/DataTarget/ClassificationstoreBatch.php
+++ b/src/Mapping/DataTarget/ClassificationstoreBatch.php
@@ -44,6 +44,7 @@ class ClassificationstoreBatch implements DataTargetInterface
     public function assignData(ElementInterface $element, $data)
     {
         $getter = 'get' . ucfirst($this->fieldName);
+        $setter = 'set' . ucfirst($this->fieldName);
         $classificationStore = $element->$getter();
 
         if ($classificationStore instanceof \Pimcore\Model\DataObject\Classificationstore) {
@@ -61,6 +62,8 @@ class ClassificationstoreBatch implements DataTargetInterface
 
                     $classificationStore->setLocalizedKeyValue($keyParts[0], $keyParts[1], $value, $this->language);
                     $classificationStore->setActiveGroups($classificationStore->getActiveGroups() + [$keyParts[0] => true]);
+
+                    $element->$setter($classificationStore, $this->language);
                 }
             }
         } else {


### PR DESCRIPTION
Linked issue: [69](https://github.com/pimcore/data-importer/issues/69)

Solves the problem with import classification store for the "Find parent" strategy in "Element Creation" resolver with inheritance enabled in same classes for both parent and child.