### PR TITLE
Allow import if json root is an object

### DIFF
--- a/src/DataSource/Interpreter/JsonFileInterpreter.php
+++ b/src/DataSource/Interpreter/JsonFileInterpreter.php
@@ -35,7 +35,13 @@ class JsonFileInterpreter extends AbstractInterpreter
         if ($this->cachedFilePath === $path && !empty($this->cachedContent)) {
             $content = file_get_contents($path);
 
-            return json_decode($this->prepareContent($content), true);
+            $data = json_decode($this->prepareContent($content), true);
+
+            if (count($data) < 1) {
+                return $data;
+            } else {
+                return [$data];
+            }
         } else {
             return $this->cachedContent;
         }


### PR DESCRIPTION
Problem:

JSON Structures like these can't be imported:

`{'success':true, 'data':[], 'message':''}`

because they can't be looped in

`foreach ($data as $dataRow) {`

Error Message:

> Preview Error: Warning: Invalid argument supplied for foreach()