### PR TITLE
Fix an error, that a quantity value can be null if value is null

### DIFF
--- a/src/Mapping/Operator/Factory/QuantityValue.php
+++ b/src/Mapping/Operator/Factory/QuantityValue.php
@@ -85,8 +85,9 @@ class QuantityValue extends AbstractOperator
                 $unitId = $this->staticUnitId;
         }
 
+        $value = $value ?? null;
         return new \Pimcore\Model\DataObject\Data\QuantityValue(
-            floatval($value ?? null),
+            $value === null ? null : floatval($value),
             $unitId ?? null
         );
     }

--- a/src/Mapping/Operator/Factory/QuantityValueArray.php
+++ b/src/Mapping/Operator/Factory/QuantityValueArray.php
@@ -30,8 +30,9 @@ class QuantityValueArray extends AbstractOperator
         $result = [];
 
         foreach ($inputData as $key => $data) {
+            $value = $data[0] ?? null;
             $result[$key] = new \Pimcore\Model\DataObject\Data\QuantityValue(
-                floatval($data[0] ?? null),
+                $value === null ? null : floatval($value),
                 $data[1] ?? null
             );
         }


### PR DESCRIPTION
With this pull request it is possible to import null values with the quantity value type.