### PR TITLE
Fix: array_merge(): Argument #2 must be of type array, string given

### DIFF
--- a/src/Controller/ConfigDataObjectController.php
+++ b/src/Controller/ConfigDataObjectController.php
@@ -284,7 +284,9 @@ class ConfigDataObjectController extends \Pimcore\Bundle\AdminBundle\Controller\
 
             $mappedColumns = [];
             foreach (($config['mappingConfig'] ?? []) as $mapping) {
-                $mappedColumns = array_merge($mappedColumns, ($mapping['dataSourceIndex'] ?? []));
+                if (isset($mapping['dataSourceIndex']) && is_array($mapping['dataSourceIndex'])) {
+                    $mappedColumns = array_merge($mappedColumns, $mapping['dataSourceIndex']);
+                }
             }
             $mappedColumns = array_unique($mappedColumns);
 


### PR DESCRIPTION
$mapping['dataSourceIndex'] was an empty string instead of an array
```
Timestamp: Tue Apr 05 2022 00:20:18 GMT+0200 (Mitteleuropäische Sommerzeit)
Status: 500 | 
URL: /admin/pimcoredataimporter/dataobject/config/load-preview-data
Method: POST
Message: array_merge(): Argument #2 must be of type array, string given
Trace: 
in /var/www/html/vendor/pimcore/data-importer/src/Controller/ConfigDataObjectController.php:287
#0 /var/www/html/vendor/pimcore/data-importer/src/Controller/ConfigDataObjectController.php(287): array_merge(Array, '')
#1 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(152): Pimcore\Bundle\DataImporterBundle\Controller\ConfigDataObjectController->loadDataPreviewAction(Object(Symfony\Component\HttpFoundation\Request), Object(Pimcore\Bundle\DataImporterBundle\Settings\ConfigurationPreparationService), Object(Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter\InterpreterFactory), Object(Pimcore\Translation\Translator))
#2 /var/www/html/vendor/symfony/http-kernel/HttpKernel.php(74): Symfony\Component\HttpKernel\HttpKernel->handleRaw(Object(Symfony\Component\HttpFoundation\Request), 1)
#3 /var/www/html/vendor/symfony/http-kernel/Kernel.php(202): Symfony\Component\HttpKernel\HttpKernel->handle(Object(Symfony\Component\HttpFoundation\Request), 1, true)
#4 /var/www/html/public/index.php(36): Symfony\Component\HttpKernel\Kernel->handle(Object(Symfony\Component\HttpFoundation\Request))
#5 {main}
```