### PR TITLE
Make getCurrentHash() always return string.

### DIFF
--- a/src/DataSource/Interpreter/DeltaChecker/DeltaChecker.php
+++ b/src/DataSource/Interpreter/DeltaChecker/DeltaChecker.php
@@ -56,7 +56,7 @@ class DeltaChecker
         } catch (TableNotFoundException $exception) {
             return $this->createTableIfNotExisting(function () use ($configName, $id) {
                 $this->getCurrentHash($configName, $id);
-            });
+            }) ?? '';
         }
     }
 


### PR DESCRIPTION
When I tried to use the hasChanged method of the DeltaChecker class, I got an error message if the database table for the delta check did not exist yet.

`Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter\DeltaChecker\DeltaChecker::getCurrentHash(): Return value must be of type string, null returned`

I think this solution matches existing solution in try-block (see line 55 of Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter\DeltaChecker\DeltaChecker)