### PR TITLE
[Improvement] Add an options to disable info logs for parallel and sequential import commands

### DIFF
--- a/src/Command/ParallelProcessQueueCommand.php
+++ b/src/Command/ParallelProcessQueueCommand.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Console\AbstractCommand;
 use Pimcore\Console\Traits\Parallelization;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ParallelProcessQueueCommand extends AbstractCommand
@@ -54,6 +55,7 @@ class ParallelProcessQueueCommand extends AbstractCommand
         $this
             ->setName('datahub:data-importer:process-queue-parallel')
             ->setDescription('Processes all items of the queue that can be executed parallel.')
+            ->addOption('no-logs', null, InputOption::VALUE_NONE, 'Add this option to suppress info logs')
         ;
     }
 
@@ -79,6 +81,6 @@ class ParallelProcessQueueCommand extends AbstractCommand
      */
     protected function runSingleCommand(string $item, InputInterface $input, OutputInterface $output): void
     {
-        $this->importProcessingService->processQueueItem((int) $item);
+        $this->importProcessingService->processQueueItem((int) $item, !$input->getOption('no-logs'));
     }
 }

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -53,6 +53,7 @@ class SequentialProcessQueueCommand extends AbstractCommand
         $this
             ->setName('datahub:data-importer:process-queue-sequential')
             ->setDescription('Processes all items of the queue that need to be executed sequential.')
+            ->addOption('no-logs', null, InputOption::VALUE_NONE, 'Add this option to suppress info logs')
         ;
     }
 
@@ -72,7 +73,7 @@ class SequentialProcessQueueCommand extends AbstractCommand
         $progressBar->start();
 
         foreach ($itemIds as $id) {
-            $this->importProcessingService->processQueueItem($id);
+            $this->importProcessingService->processQueueItem($id, !$input->getOption('no-logs'));
             $progressBar->advance();
         }
 

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -20,6 +20,7 @@ use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Console\AbstractCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;


### PR DESCRIPTION
resolves #79 

I don't know if this is the way to go about this, but it works. To disable info logs during imports, add the --no-logs

For example : 
```bash
bin/console datahub:data-importer:process-queue-parallel --no-logs
```