### PR TITLE
Fixed fatal import error, if object loaded by path.

### DIFF
--- a/src/Resources/public/js/pimcore/configuration/components/mapping/operator/loadDataObject.js
+++ b/src/Resources/public/js/pimcore/configuration/components/mapping/operator/loadDataObject.js
@@ -99,7 +99,7 @@ pimcore.plugin.pimcoreDataImporterBundle.configuration.components.mapping.operat
             }
         });
 
-        const systemAttributes = ['id', 'fullpath', 'key'];
+        const systemAttributes = ['id', 'path', 'key'];
 
         const partialMatch = Ext.create('Ext.form.field.Checkbox', {
             fieldLabel: t('plugin_pimcore_datahub_data_importer_configpanel_transformation_pipeline_accept_partial_match'),


### PR DESCRIPTION
vendor/pimcore/data-importer/src/Tool/DataObjectLoader.php(108): Pimcore\Model\DataObject\Concrete::__callStatic('getByfullpath', Array)

The preview use path as attribute, but importer uses fullpath. getByfullpath does not exists in pimcore, only getBypath.