### PR TITLE
[Bug] Fixed handling of many-to-many relations on localized fields.

### DIFF
--- a/src/Mapping/DataTarget/ManyToManyRelation.php
+++ b/src/Mapping/DataTarget/ManyToManyRelation.php
@@ -17,6 +17,7 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget;
 
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\DataObject\Data\ElementMetadata;
 use Pimcore\Model\DataObject\Data\ObjectMetadata;
 use Pimcore\Model\Element\Service;
@@ -53,6 +54,16 @@ class ManyToManyRelation extends Direct
         }
 
         $fieldDefinition = $definition->getFieldDefinition($fieldName);
+        if ($fieldDefinition === null) {
+            $localizedFields = $definition->getFieldDefinition('localizedfields');
+            if ($localizedFields instanceof LocalizedFields) {
+                $fieldDefinition = $localizedFields->getFieldDefinition($fieldName);
+            }
+        }
+
+        if ($fieldDefinition === null) {
+            throw new InvalidConfigurationException(sprintf('Field definition for field "%s" not found.', $fieldName));
+        }
 
         switch ($fieldDefinition->getFieldtype()) {
             case 'manyToManyRelation':


### PR DESCRIPTION
As the standard pimcore `Definition::getFieldDefinition` functionality doesn't take localized fields into account, an extra check has been added, when assigning many-to-many relational data for localized fields.

Example on how to reproduce the original issue:
1. Create import csv with an object id and an array of assets: (e.g. `100;102|103`)
1. Assign a localized many-to-many field - such as an array of assets - to the target
1. Start the import, which will result in 
```
In ManyToManyRelation.php line 68:

  Call to a member function getFieldtype() on null
```