### PR TITLE
[Task]: remove logger aliases from phpStan

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     }
   },
   "require": {
+    "pimcore/compatibility-bridge-v10": "1.x-dev",
     "php": "~8.0.0 || ~8.1.0 || ~8.2.0",
     "ext-fileinfo": "*",
     "ext-json": "*",

--- a/phpstan-bootstrap.php
+++ b/phpstan-bootstrap.php
@@ -20,6 +20,3 @@ include PIMCORE_PROJECT_ROOT . '/vendor/autoload.php';
 if (!defined('PIMCORE_TEST')) {
     define('PIMCORE_TEST', true);
 }
-
-@class_alias(ApplicationLogger::class, 'Pimcore\Log\ApplicationLogger');
-@class_alias(FileObject::class, 'Pimcore\Log\FileObject');


### PR DESCRIPTION
Follow up https://github.com/pimcore/pimcore/issues/14739

Remove aliases of the logger and use the compatability-bridge-v10 package instead