### PR TITLE
docs: remove "update dependencies" from install instructions

### DIFF
--- a/doc/01_Installation.md
+++ b/doc/01_Installation.md
@@ -5,7 +5,7 @@ to be installed first.
 To install Pimcore Data Importer use following commands:
 
 ```bash
-composer require pimcore/data-importer --with-all-dependencies
+composer require pimcore/data-importer
 ./bin/console pimcore:bundle:enable PimcoreDataImporterBundle
 ./bin/console pimcore:bundle:install PimcoreDataImporterBundle
 ```


### PR DESCRIPTION
Although it is definitely recommended to keep your Pimcore installation up-to-date, any updates should be done as a dedicated task (some updates have release notes requiring some extra configuration/changes and all updates should be tested before passing to production). Installing this bundle shouldn't have a full package update as side-effect.

This commit reverts dc213f126aae988ba07ee2019aaba04ff3b4ae83