### PR TITLE
[Bugfix] Extend empty check to "0" for LoadingDataObject mapping

### DIFF
--- a/src/Mapping/Operator/Simple/LoadDataObject.php
+++ b/src/Mapping/Operator/Simple/LoadDataObject.php
@@ -106,7 +106,7 @@ class LoadDataObject extends AbstractOperator
         foreach ($inputData as $data) {
             $object = null;
             $logMessage = '';
-            if (empty($data) === false) {
+            if (empty($data) === false || $data === "0") {
                 if ($this->loadStrategy === self::LOAD_STRATEGY_PATH) {
                     $object = $this->dataObjectLoader->loadByPath(trim($data));
                     $logMessage = 'by path `' . trim($data) . '`';


### PR DESCRIPTION
The current check for empty in https://github.com/pimcore/data-importer/blob/596fd8490de315b87643a4176dc55a2e0b277c76/src/Mapping/Operator/Simple/LoadDataObject.php#L109 also ignores the string "0". Thus it is not possible to use this for the import on attributes. Even if it does not make much sense this also applies to a path specification.
In our current project we have an identifier attribute that can have the value (the string) "0" among others. Without the fix an import is not possible here.