### PR TITLE
[Bug] Add null check to cleanup

### DIFF
--- a/src/DataSource/Interpreter/AbstractInterpreter.php
+++ b/src/DataSource/Interpreter/AbstractInterpreter.php
@@ -247,6 +247,9 @@ abstract class AbstractInterpreter implements InterpreterInterface
         $elementsToCleanup = array_diff($existingElements, $this->identifierCache);
 
         foreach ($elementsToCleanup as $identifier) {
+            if ($identifier === null) {
+                continue;
+            }
             $this->logger->debug(sprintf('Adding item `%s` of `%s` to cleanup queue.', $identifier, $this->configName));
             $this->queueService->addItemToQueue($this->configName, $this->executionType, ImportProcessingService::JOB_TYPE_CLEANUP, $identifier);
         }


### PR DESCRIPTION
`$this->queueService->addItemToQueue` requires argument #4 to be string, however  `$this->resolver->loadFullIdentifierList();` doesn't guarantee that the returned array contains only strings. If there are some (unpublished) objects that don't have the identifier attribute filled in, the returned array may contain nulls and cause a fatal error.