### PR TITLE
Stop bloating Application Logger

### DIFF
--- a/src/Processing/ImportPreparationService.php
+++ b/src/Processing/ImportPreparationService.php
@@ -202,9 +202,6 @@ class ImportPreparationService
         if (!($config['general']['active'] ?? false)) {
             $message = "Configuration '$configName' is not active, skipping preparation execution.";
             $this->logger->info($message);
-            $this->applicationLogger->info($message, [
-                'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName
-            ]);
 
             return false;
         }


### PR DESCRIPTION
We have a lot of inactive imports. We also use the scheduler for importing via (every 5 min):

`bin/console datahub:data-importer:execute-cron `

Over time this bloats the Application Logger and the DB with soo many:

"Configuration FOO is not active, skipping preparation execution."

Since it gets logged can we skip this in the Application Logger?