### PR TITLE
[Bug] Fix csv being allowed as text/html, use Symfony MIME guesser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     "nesbot/carbon": "^2.27",
     "pimcore/data-hub": "^1.6",
     "pimcore/pimcore": "^10.6 || ^11.0",
+    "symfony/mime": "^5.2 || ^6.2",
     "webmozarts/console-parallelization": "^1.2.0 || ^2.0.0"
   },
   "require-dev": {

--- a/src/DataSource/Interpreter/CsvFileInterpreter.php
+++ b/src/DataSource/Interpreter/CsvFileInterpreter.php
@@ -72,7 +72,8 @@ class CsvFileInterpreter extends AbstractInterpreter
             }
         }
 
-        $csvMimes = ['text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/x-csv', 'text/x-csv', 'text/csv', 'application/csv', 'application/excel', 'application/vnd.msexcel', 'text/plain'];
+        // csv that has html tags might be recognized as text/html
+        $csvMimes = ['text/html','text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/x-csv', 'text/x-csv', 'text/csv', 'application/csv', 'application/excel', 'application/vnd.msexcel', 'text/plain'];
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $path);
         finfo_close($finfo);

--- a/src/DataSource/Interpreter/CsvFileInterpreter.php
+++ b/src/DataSource/Interpreter/CsvFileInterpreter.php
@@ -73,7 +73,7 @@ class CsvFileInterpreter extends AbstractInterpreter
         }
 
         // csv that has html tags might be recognized as text/html
-        $csvMimes = ['text/html','text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/x-csv', 'text/x-csv', 'text/csv', 'application/csv', 'application/excel', 'application/vnd.msexcel', 'text/plain'];
+        $csvMimes = ['text/html', 'text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/x-csv', 'text/x-csv', 'text/csv', 'application/csv', 'application/excel', 'application/vnd.msexcel', 'text/plain'];
         $finfo = finfo_open(FILEINFO_MIME_TYPE);
         $mime = finfo_file($finfo, $path);
         finfo_close($finfo);

--- a/src/DataSource/Interpreter/CsvFileInterpreter.php
+++ b/src/DataSource/Interpreter/CsvFileInterpreter.php
@@ -16,6 +16,7 @@
 namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
+use Symfony\Component\Mime\MimeTypes;
 
 class CsvFileInterpreter extends AbstractInterpreter
 {
@@ -74,9 +75,8 @@ class CsvFileInterpreter extends AbstractInterpreter
 
         // csv that has html tags might be recognized as text/html
         $csvMimes = ['text/html', 'text/x-comma-separated-values', 'text/comma-separated-values', 'application/octet-stream', 'application/vnd.ms-excel', 'application/x-csv', 'text/x-csv', 'text/csv', 'application/csv', 'application/excel', 'application/vnd.msexcel', 'text/plain'];
-        $finfo = finfo_open(FILEINFO_MIME_TYPE);
-        $mime = finfo_file($finfo, $path);
-        finfo_close($finfo);
+        $mimeTypes = new MimeTypes();
+        $mime = $mimeTypes->guessMimeType($path);
 
         return in_array($mime, $csvMimes);
     }


### PR DESCRIPTION
Potentially resolves https://github.com/pimcore/data-importer/issues/371

Looking for feedback and better alternatives (symfony/mime guesser also behaves the same)
More details on https://github.com/pimcore/data-importer/issues/371#issuecomment-1790811919