### PR TITLE
[Fix] (re)Fix Field definition for field not found if field name is 'key'

### DIFF
--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -74,7 +74,9 @@ class Direct implements DataTargetInterface
     {
         $setterParts = explode('.', $this->fieldName);
 
-        if (count($setterParts) === 1) {
+        if ($this->fieldName === 'key') {
+            $this->doAssignData($element, $this->fieldName, $data);
+        } elseif (count($setterParts) === 1) {
             //direct class attribute
             $getter = 'get' . ucfirst($this->fieldName);
             if (!$this->checkAssignData($data, $element, $getter)) {


### PR DESCRIPTION
Resolves #369

Directly assign the key in the case where the "Direct" target strategy is used alongside with "SYSTEM Key".

Currently, an error is thrown because `key` is not in `$this->getFieldDefinition()` since it is a system field

@dvesh3 related to your PR #377