### PR TITLE
fix explode operator to return an empty array when input is empty

### DIFF
--- a/src/Mapping/Operator/Simple/Explode.php
+++ b/src/Mapping/Operator/Simple/Explode.php
@@ -58,9 +58,15 @@ class Explode extends AbstractOperator
 
                 return $explodedArray;
             } else {
+                if (empty($inputData)) {
+                    return [];
+                }
                 return explode($this->delimiter, $inputData);
             }
         } else {
+            if (empty($inputData)) {
+                return [];
+            }
             return [$inputData];
         }
     }

--- a/src/Mapping/Operator/Simple/Explode.php
+++ b/src/Mapping/Operator/Simple/Explode.php
@@ -45,6 +45,9 @@ class Explode extends AbstractOperator
      */
     public function process($inputData, bool $dryRun = false)
     {
+        if (empty($inputData)) {
+            return [];
+        }
         if (!empty($this->delimiter)) {
             if (is_array($inputData)) {
                 $explodedArray = [];
@@ -58,15 +61,9 @@ class Explode extends AbstractOperator
 
                 return $explodedArray;
             } else {
-                if (empty($inputData)) {
-                    return [];
-                }
                 return explode($this->delimiter, $inputData);
             }
         } else {
-            if (empty($inputData)) {
-                return [];
-            }
             return [$inputData];
         }
     }


### PR DESCRIPTION
When the input is an empty string, the return value is an array with a "null" value: [null].
This pull request fixes this issue. An empty string results in an empty array.