### PR TITLE
Skip UTF8 byte order mark in CSV files

### DIFF
--- a/src/DataSource/Interpreter/CsvFileInterpreter.php
+++ b/src/DataSource/Interpreter/CsvFileInterpreter.php
@@ -133,6 +133,7 @@ class CsvFileInterpreter extends AbstractInterpreter
 
         return new PreviewData($columns, $previewData, $readRecordNumber, $mappedColumns);
     }
+
     private function skipByteOrderMark($handle): void
     {
         $bom = fread($handle, strlen(self::UTF8_BOM));

--- a/tests/bin/docker-compose.yml
+++ b/tests/bin/docker-compose.yml
@@ -22,7 +22,7 @@ services:
             PIMCORE_TEST: 1
             PIMCORE_TEST_DB_DSN: "mysql://pimcore:pimcore@db:3306/pimcore_test"
         depends_on:
-            - db            
+            - db
         volumes:
             - ../../.:/var/www/html
             - /var/www/html/vendor


### PR DESCRIPTION
Currently if a CSV file contains a [byte order mark](https://en.wikipedia.org/wiki/Byte_order_mark) it is treated as data. This is visible on this screenshot from Pimcore Enterprise Demo:

![Screenshot from 2024-05-20 13-41-32](https://github.com/pimcore/data-importer/assets/2362246/66b712cd-dd52-4f95-a889-fb7dd8d18ab7)

The data for row 0 (id) is in quotes, because it also contains byte order mark which is interpreted as a white space.

This MR changes that by skipping UTF8 byte order mark.

Sample CSV file: [test_utf8_bom.csv](https://github.com/pimcore/data-importer/files/15376568/test_utf8_bom.csv)
