### PR TITLE
[Feature]: Automaticaly set imported element userModification

### DIFF
--- a/doc/04_Import_Execution_Details.md
+++ b/doc/04_Import_Execution_Details.md
@@ -47,6 +47,7 @@ The actual processing is the same for both types and consists of following steps
 - Update published state of element based on publish strategy.
 - Process mappings and transformation pipelines for each mapping.
 - Assign transformation result to data element based on data target definition.
+- Assign userModification to data element if possible.
 
 Cleanup jobs are simpler and consist of following steps: 
 - Look for existing data element based on loading strategy.

--- a/src/DataSource/Interpreter/AbstractInterpreter.php
+++ b/src/DataSource/Interpreter/AbstractInterpreter.php
@@ -23,6 +23,7 @@ use Pimcore\Bundle\DataImporterBundle\Resolver\Resolver;
 use Pimcore\Log\ApplicationLogger;
 use Pimcore\Log\FileObject;
 use Pimcore\Model\Tool\TmpStore;
+use Pimcore\Tool;
 use Psr\Log\LoggerAwareTrait;
 
 abstract class AbstractInterpreter implements InterpreterInterface
@@ -212,10 +213,12 @@ abstract class AbstractInterpreter implements InterpreterInterface
             $createQueueItem = $this->deltaChecker->hasChanged($this->configName, $this->idDataIndex, $data);
         }
 
+        $userOwner = Tool\Admin::getCurrentUser()?->getId() ?? 0;
+
         //create queue item
         if ($createQueueItem) {
             $this->logger->debug(sprintf('Adding item `%s` of `%s` to processing queue.', ($data[$this->idDataIndex] ?? null), $this->configName));
-            $this->queueService->addItemToQueue($this->configName, $this->executionType, ImportProcessingService::JOB_TYPE_PROCESS, json_encode($data));
+            $this->queueService->addItemToQueue($this->configName, $this->executionType, ImportProcessingService::JOB_TYPE_PROCESS, json_encode($data), $userOwner);
         } else {
             $message = sprintf("Import data of item `%s` of `%s` didn't change, not adding to queue.", ($data[$this->idDataIndex] ?? null), $this->configName);
             $this->logger->debug($message);

--- a/src/DataSource/Interpreter/AbstractInterpreter.php
+++ b/src/DataSource/Interpreter/AbstractInterpreter.php
@@ -24,6 +24,7 @@ use Pimcore\Log\ApplicationLogger;
 use Pimcore\Log\FileObject;
 use Pimcore\Model\Tool\TmpStore;
 use Pimcore\Tool;
+use Pimcore\Tool\Admin;
 use Psr\Log\LoggerAwareTrait;
 
 abstract class AbstractInterpreter implements InterpreterInterface
@@ -213,7 +214,8 @@ abstract class AbstractInterpreter implements InterpreterInterface
             $createQueueItem = $this->deltaChecker->hasChanged($this->configName, $this->idDataIndex, $data);
         }
 
-        $userOwner = Tool\Admin::getCurrentUser()?->getId() ?? 0;
+        // If there is no user logged in, we use the system user (ID 0) as userOwner
+        $userOwner = Admin::getCurrentUser()?->getId() ?? 0;
 
         //create queue item
         if ($createQueueItem) {

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -15,7 +15,7 @@
 
 namespace Pimcore\Bundle\DataImporterBundle;
 
-use Pimcore\Bundle\DataImporterBundle\Migrations\Version20220304130000;
+use Pimcore\Bundle\DataImporterBundle\Migrations\Version20240715160305;
 use Pimcore\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 use Pimcore\Model\User\Permission;
 
@@ -57,6 +57,6 @@ class Installer extends SettingsStoreAwareInstaller
 
     public function getLastMigrationVersionClassName(): ?string
     {
-        return Version20220304130000::class;
+        return Version20240715160305::class;
     }
 }

--- a/src/Migrations/Version20240715160305.php
+++ b/src/Migrations/Version20240715160305.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Commercial License (PCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PCL
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
+use Pimcore\Migrations\BundleAwareMigration;
+
+class Version20240715160305 extends BundleAwareMigration
+{
+    public function up(Schema $schema): void
+    {
+        if ($schema->hasTable(QueueService::QUEUE_TABLE_NAME)) {
+            $queueTable = $schema->getTable(QueueService::QUEUE_TABLE_NAME);
+            $queueTable->addColumn('userOwner', 'integer', ['notnull' => true, 'default' => 0])->setUnsigned(true);
+            $queueTable->addIndex(['userOwner'], 'bundle_index_queue_executiontype_userOwner');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        if ($schema->hasTable(QueueService::QUEUE_TABLE_NAME)) {
+            $queueTable = $schema->getTable(QueueService::QUEUE_TABLE_NAME);
+            $queueTable->dropColumn('userOwner');
+            $queueTable->dropIndex('bundle_index_queue_executiontype_userOwner');
+        }
+    }
+
+    protected function getBundleName(): string
+    {
+        return 'PimcoreDataImporterBundle';
+    }
+}

--- a/src/Queue/QueueService.php
+++ b/src/Queue/QueueService.php
@@ -51,25 +51,26 @@ class QueueService
      *
      * @throws Exception
      */
-    public function addItemToQueue(string $configName, string $executionType, string $jobType, string $data): void
+    public function addItemToQueue(string $configName, string $executionType, string $jobType, string $data, int $userOwner = 0): void
     {
         $db = $this->getDb();
         try {
             $db->executeQuery(sprintf(
                 'INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE timestamp = VALUES(timestamp)',
                 self::QUEUE_TABLE_NAME,
-                implode(',', ['timestamp', 'configName', 'data', 'executionType', 'jobType']),
+                implode(',', ['timestamp', 'configName', 'data', 'executionType', 'jobType', 'userOwner']),
                 implode(',', [
                     $this->getCurrentQueueTableOperationTime(),
                     $db->quote($configName),
                     $db->quote($data),
                     $db->quote($executionType),
-                    $db->quote($jobType)
+                    $db->quote($jobType),
+                    $userOwner
                 ])
             ));
         } catch (TableNotFoundException $exception) {
-            $this->createQueueTableIfNotExisting(function () use ($configName, $executionType, $jobType, $data) {
-                $this->addItemToQueue($configName, $executionType, $jobType, $data);
+            $this->createQueueTableIfNotExisting(function () use ($configName, $executionType, $jobType, $data, $userOwner) {
+                $this->addItemToQueue($configName, $executionType, $jobType, $data, $userOwner);
             });
         }
     }
@@ -86,6 +87,7 @@ class QueueService
         $this->getDb()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (
             id bigint AUTO_INCREMENT,
             timestamp bigint NULL,
+            userOwner int unsigned NOT NULL DEFAULT \'0\',
             configName varchar(80) NULL,
             `data` TEXT null,
             executionType varchar(20) NULL,
@@ -95,7 +97,8 @@ class QueueService
             PRIMARY KEY (id),
             KEY `bundle_index_queue_configName_index` (`configName`),
             KEY `bundle_index_queue_executiontype_workerId` (`executionType`, `workerId`),
-            KEY `bundle_index_queue_configName_index_executionType` (`configName`, `executionType`))
+            KEY `bundle_index_queue_configName_index_executionType` (`configName`, `executionType`),
+            KEY `bundle_index_queue_executiontype_userOwner` (`userOwner`))
         ', self::QUEUE_TABLE_NAME));
 
         if ($callable) {

--- a/src/Queue/QueueService.php
+++ b/src/Queue/QueueService.php
@@ -87,7 +87,8 @@ class QueueService
         $this->getDb()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (
             id bigint AUTO_INCREMENT,
             timestamp bigint NULL,
-            userOwner int unsigned NOT NULL DEFAULT \'0\',
+            userOwner int unsigned NOT NULL DEFAULT 0,
+
             configName varchar(80) NULL,
             `data` TEXT null,
             executionType varchar(20) NULL,


### PR DESCRIPTION
This PR solves problem of identifying who is the author of object change for manualy triggered imports.

As of now every object that was changed by import had userModification set to 0 (that is system user). 
This change introduce new column "**userOwner**" to queue table that by default is set to 0.
If user manualy trigger import it's user id is passed to queue item and later in import process it is set to element userModification property.
This will not affect automatic/cron imports.