### PR TITLE
[BUG, EC] Data Hub Data Importer does not respect overwrite flags for Key mappings

### DIFF
--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -75,6 +75,9 @@ class Direct implements DataTargetInterface
         $setterParts = explode('.', $this->fieldName);
 
         if ($this->fieldName === 'key') {
+            if (!$this->checkAssignData($data, $element, 'getKey')) {
+                return;
+            }
             $this->doAssignData($element, $this->fieldName, $data);
         } elseif (count($setterParts) === 1) {
             //direct class attribute


### PR DESCRIPTION
Resolves https://pimcore.atlassian.net/browse/PEES-419


In Data Object Importer, when setting a key, the overwrite flags are not respected. The “checkAssignData method is missing ahead of the doAssignData call in the special case where this is a key (line 75 in pimcore/pimcore-root/vendor/pimcore/data-importer/src/Mapping/DataTarget/Direct.php).
