### PR TITLE
[BUG, EC] Followup Data Hub Data Importer does not respect overwrite flags for Key mappings

### DIFF
--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -152,13 +152,13 @@ class Direct implements DataTargetInterface
             $fieldName = $fieldNameParts[2];
         }
 
-        try {
+        if ($this->fieldName === 'key'){
+            $currentDataIsEmpty = empty($currentData);
+            $newDataIsEmpty = empty($newData);
+        } else {
             $fieldDefinition = $this->getFieldDefinition($valueContainer, $fieldName);
             $currentDataIsEmpty = $fieldDefinition->isEmpty($currentData);
             $newDataIsEmpty = $fieldDefinition->isEmpty($newData);
-        } catch (InvalidConfigurationException $e) {
-            $currentDataIsEmpty = empty($currentData);
-            $newDataIsEmpty = empty($newData);
         }
 
         if ($this->writeIfTargetIsNotEmpty === false && !$currentDataIsEmpty) {

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -151,13 +151,21 @@ class Direct implements DataTargetInterface
         if (count($fieldNameParts) === 3) {
             $fieldName = $fieldNameParts[2];
         }
-
-        $fieldDefinition = $this->getFieldDefinition($valueContainer, $fieldName);
-        if ($this->writeIfTargetIsNotEmpty === false && !$fieldDefinition->isEmpty($currentData)) {
+        
+        try{
+            $fieldDefinition = $this->getFieldDefinition($valueContainer, $fieldName);
+            $currentDataIsEmpty= $fieldDefinition->isEmpty($currentData);
+            $newDataIsEmpty = $fieldDefinition->isEmpty($newData);
+        } catch (InvalidConfigurationException $e) {
+            $currentDataIsEmpty= empty($currentData);
+            $newDataIsEmpty = empty($newData);
+        }
+        
+        if ($this->writeIfTargetIsNotEmpty === false && !$currentDataIsEmpty) {
             return false;
         }
 
-        if ($this->writeIfSourceIsEmpty === false && $fieldDefinition->isEmpty($newData)) {
+        if ($this->writeIfSourceIsEmpty === false && $newDataIsEmpty) {
             return false;
         }
 

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -151,16 +151,16 @@ class Direct implements DataTargetInterface
         if (count($fieldNameParts) === 3) {
             $fieldName = $fieldNameParts[2];
         }
-        
-        try{
+
+        try {
             $fieldDefinition = $this->getFieldDefinition($valueContainer, $fieldName);
-            $currentDataIsEmpty= $fieldDefinition->isEmpty($currentData);
+            $currentDataIsEmpty = $fieldDefinition->isEmpty($currentData);
             $newDataIsEmpty = $fieldDefinition->isEmpty($newData);
         } catch (InvalidConfigurationException $e) {
-            $currentDataIsEmpty= empty($currentData);
+            $currentDataIsEmpty = empty($currentData);
             $newDataIsEmpty = empty($newData);
         }
-        
+
         if ($this->writeIfTargetIsNotEmpty === false && !$currentDataIsEmpty) {
             return false;
         }

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -152,7 +152,7 @@ class Direct implements DataTargetInterface
             $fieldName = $fieldNameParts[2];
         }
 
-        if ($this->fieldName === 'key'){
+        if ($this->fieldName === 'key') {
             $currentDataIsEmpty = empty($currentData);
             $newDataIsEmpty = empty($newData);
         } else {

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -227,6 +227,7 @@ class ImportProcessingService
                 $event = new PreSaveEvent($configName, $importDataRow, $element);
                 $this->eventDispatcher->dispatch($event);
 
+                $this->checkKey($element);
                 $element->save();
 
                 $event = new PostSaveEvent($configName, $importDataRow, $element);
@@ -389,5 +390,12 @@ class ImportProcessingService
         $infoEntryId = self::INFO_ENTRY_ID_PREFIX . $configName;
         TmpStore::delete($infoEntryId);
         $this->queueService->cleanupQueueItems($configName);
+    }
+
+    private function checkKey(ElementInterface $element): void
+    {
+        if(empty($element->getKey())) {
+            $element->setKey(uniqid('import-', true));
+        }
     }
 }

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -394,7 +394,7 @@ class ImportProcessingService
 
     private function checkKey(ElementInterface $element): void
     {
-        if(empty($element->getKey())) {
+        if (empty($element->getKey())) {
             $element->setKey(uniqid('import-', true));
         }
     }

--- a/src/Resolver/Factory/DataObjectFactory.php
+++ b/src/Resolver/Factory/DataObjectFactory.php
@@ -15,6 +15,7 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Resolver\Factory;
 
+use Exception;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
@@ -44,9 +45,9 @@ class DataObjectFactory implements FactoryInterface
 
     /**
      * @throws InvalidConfigurationException
-     * @throws \Exception
+     * @throws Exception
      */
-    public function createNewElement(bool $assignUniqueIdAsKey = true): ElementInterface
+    public function createNewElement(): ElementInterface
     {
         $class = ClassDefinition::getById($this->subType);
         if (empty($class)) {
@@ -62,9 +63,7 @@ class DataObjectFactory implements FactoryInterface
             );
         }
 
-        if($assignUniqueIdAsKey) {
-            $element->setKey(uniqid('import-', true));
-        }
+        $element->setKey(uniqid('import-', true));
 
         return $element;
     }

--- a/src/Resolver/Factory/DataObjectFactory.php
+++ b/src/Resolver/Factory/DataObjectFactory.php
@@ -62,7 +62,7 @@ class DataObjectFactory implements FactoryInterface
             );
         }
 
-        if($assignUniqueIdAsKey) {
+        if ($assignUniqueIdAsKey) {
             $element->setKey(uniqid('import-', true));
         }
 

--- a/src/Resolver/Factory/DataObjectFactory.php
+++ b/src/Resolver/Factory/DataObjectFactory.php
@@ -42,7 +42,11 @@ class DataObjectFactory implements FactoryInterface
         $this->subType = $subType;
     }
 
-    public function createNewElement(): ElementInterface
+    /**
+     * @throws InvalidConfigurationException
+     * @throws \Exception
+     */
+    public function createNewElement(bool $assignUniqueIdAsKey = true): ElementInterface
     {
         $class = ClassDefinition::getById($this->subType);
         if (empty($class)) {
@@ -52,12 +56,16 @@ class DataObjectFactory implements FactoryInterface
         $className = '\\Pimcore\\Model\\DataObject\\' . ucfirst($class->getName());
         $element = $this->modelFactory->build($className);
 
-        if ($element instanceof ElementInterface) {
-            $element->setKey(uniqid('import-', true));
-
-            return $element;
+        if (!($element instanceof ElementInterface)) {
+            throw new InvalidConfigurationException(
+                "Object of class `{$this->subType}` could not be created."
+            );
         }
 
-        throw new InvalidConfigurationException("Object of class `{$this->subType}` could not be created.");
+        if($assignUniqueIdAsKey) {
+            $element->setKey(uniqid('import-', true));
+        }
+
+        return $element;
     }
 }

--- a/src/Resolver/Factory/FactoryInterface.php
+++ b/src/Resolver/Factory/FactoryInterface.php
@@ -31,5 +31,5 @@ interface FactoryInterface
      *
      * @return ElementInterface
      */
-    public function createNewElement(): ElementInterface;
+    public function createNewElement(bool $assignUniqueIdAsKey = true): ElementInterface;
 }

--- a/src/Resolver/Factory/FactoryInterface.php
+++ b/src/Resolver/Factory/FactoryInterface.php
@@ -31,5 +31,5 @@ interface FactoryInterface
      *
      * @return ElementInterface
      */
-    public function createNewElement(bool $assignUniqueIdAsKey = true): ElementInterface;
+    public function createNewElement(): ElementInterface;
 }

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -154,6 +154,7 @@ class Resolver
             /**
              * Reset key for new element, otherwise a key, that gets passed in the input data, would not be used.
              * See checkKey method in ImportProcessingService, which adds the key again if necessary.
+             *
              * @see \Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService::checkKey
              *
              * Needs to be done here, because adding a parameter to createNewElement would be a bc break.

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -150,8 +150,15 @@ class Resolver
         }
 
         if (empty($element)) {
-            $hasKeySet = array_key_exists('key', $inputData) && !empty($inputData['key']);
-            $element = $this->getElementFactory()->createNewElement($hasKeySet);
+            $element = $this->getElementFactory()->createNewElement();
+            /**
+             * Reset key for new element, otherwise a key, that gets passed in the input data, would not be used.
+             * See checkKey method in ImportProcessingService, which adds the key again if necessary.
+             * @see \Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService::checkKey
+             *
+             * Needs to be done here, because adding a parameter to createNewElement would be a bc break.
+             */
+            $element->setKey('');
             $this->getCreateLocationStrategy()->updateParent($element, $inputData);
             $justCreated = true;
         } else {

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -150,7 +150,8 @@ class Resolver
         }
 
         if (empty($element)) {
-            $element = $this->getElementFactory()->createNewElement();
+            $hasKeySet = array_key_exists('key', $inputData) && !empty($inputData['key']);
+            $element = $this->getElementFactory()->createNewElement($hasKeySet);
             $this->getCreateLocationStrategy()->updateParent($element, $inputData);
             $justCreated = true;
         } else {


### PR DESCRIPTION
Followup #425 

`checkAssignData` checks `FieldDefinition` and `key` is a system field, so it won't work
![image](https://github.com/user-attachments/assets/db82555f-360f-4642-b54c-02d71ad7503c)

