### PR TITLE
Fix usage of cache in XmlFileInterpreter

### DIFF
--- a/src/DataSource/Interpreter/XmlFileInterpreter.php
+++ b/src/DataSource/Interpreter/XmlFileInterpreter.php
@@ -53,7 +53,7 @@ class XmlFileInterpreter extends AbstractInterpreter
      */
     protected function loadData(string $path)
     {
-        if ($this->cachedFilePath === $path && !empty($this->cachedContent)) {
+        if ($this->cachedFilePath !== $path || !empty($this->cachedContent)) {
             $schema = $this->schema;
             $dom = XmlUtils::loadFile($path, function ($dom) use ($schema) {
                 if (!empty($schema)) {

--- a/src/DataSource/Interpreter/XmlFileInterpreter.php
+++ b/src/DataSource/Interpreter/XmlFileInterpreter.php
@@ -44,6 +44,17 @@ class XmlFileInterpreter extends AbstractInterpreter
      */
     protected $cachedFilePath = null;
 
+    protected function loadDataRaw(string $path){
+        $schema = $this->schema;
+        return XmlUtils::loadFile($path, function ($dom) use ($schema) {
+            if (!empty($schema)) {
+                return @$dom->schemaValidateSource($schema);
+            }
+
+            return true;
+        });
+    }
+
     /**
      * @param string $path
      *
@@ -54,14 +65,7 @@ class XmlFileInterpreter extends AbstractInterpreter
     protected function loadData(string $path)
     {
         if ($this->cachedFilePath !== $path || !empty($this->cachedContent)) {
-            $schema = $this->schema;
-            $dom = XmlUtils::loadFile($path, function ($dom) use ($schema) {
-                if (!empty($schema)) {
-                    return @$dom->schemaValidateSource($schema);
-                }
-
-                return true;
-            });
+            $dom = $this->loadDataRaw($path);
         } else {
             $dom = $this->cachedContent;
         }
@@ -100,14 +104,7 @@ class XmlFileInterpreter extends AbstractInterpreter
         }
 
         try {
-            $schema = $this->schema;
-            $dom = XmlUtils::loadFile($path, function ($dom) use ($schema) {
-                if (!empty($schema)) {
-                    return @$dom->schemaValidateSource($schema);
-                }
-
-                return true;
-            });
+            $dom = $this->loadDataRaw($path);
         } catch (XmlParsingException $exception) {
             $message = 'Error validating XML: ' . $exception->getMessage();
             $this->applicationLogger->info($message, [


### PR DESCRIPTION
The current logic to determine if cache should be used looks backward.