### PR TITLE
Add IS NULL / IS NOT NULL in loadByAttribute.

### DIFF
--- a/src/Tool/DataObjectLoader.php
+++ b/src/Tool/DataObjectLoader.php
@@ -60,7 +60,7 @@ class DataObjectLoader
 
     public function loadByAttribute(string $className,
                                     string $attributeName,
-                                    string $identifier,
+                                    ?string $identifier,
                                     string $attributeLanguage = '',
                                     bool $includeUnpublished = false,
                                     int $limit = 0,

--- a/src/Tool/DataObjectLoader.php
+++ b/src/Tool/DataObjectLoader.php
@@ -93,7 +93,13 @@ class DataObjectLoader
                 $queryFieldName = $this->getAttributeNameFromParts($objectBrickParts, false);
                 $conditions = ['objectbricks' => [$objectBrickParts[self::BRICK_NAME]]];
             }
-            $conditions['condition'] = $queryFieldName . ' ' . $operator . ' ' . Db::get()->quote($identifier);
+
+            if ((strtoupper($operator) === "IS" || strtoupper($operator) === "IS NOT") && $identifier === null) {
+                $identifierQuoted  = 'NULL';
+            } else {
+                $identifierQuoted = Db::get()->quote($identifier);
+            }
+            $conditions['condition'] = $queryFieldName . ' ' . $operator . ' ' . $identifierQuoted;
             if ($limit > 0) {
                 $conditions['limit'] = $limit;
             }


### PR DESCRIPTION
Allows working around the issue in: https://github.com/pimcore/data-importer/issues/443#issuecomment-2541779154 by extending `AttributeStrategy` with something like:
```php
    public function loadElementByIdentifier($identifier): ?ElementInterface
    {
        // empty string stored as null in DB so we need to remap
        if($identifier !== ''){
           return parent::loadElementByIdentifier($identifier);
        }
        return $this->dataObjectLoader->loadByAttribute($this->getClassName(),
                                                        $this->attributeName,
                                                        null, // $identifier,
                                                        $this->attributeLanguage,
                                                        $this->includeUnpublished,
                                                        1,
                                                        'IS' // $operator 
                                                        );
    }
```