### PR TITLE
Feature/mapping configuration logging

### DIFF
--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -260,7 +260,8 @@ class ImportProcessingService
             $this->logger->error($message . $e);
 
             $message .= $e->getMessage();
-            // $currentMapping can be null before and after the loop above, but will have a value if it errors out during the loop
+            // $currentMapping can be null before and after the loop above
+            // will have a value if it errors out during the loop
             // @phpstan-ignore-next-line
             if ($currentMapping !== null) {
                 $message .= "\nMapping Configuration: " . $currentMapping->getLabel();

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -261,7 +261,7 @@ class ImportProcessingService
 
             $message . $e->getMessage();
 
-            if ($currentMapping) {
+            if ($currentMapping !== null) {
                 $message .= "\nMapping Configuration: " . $currentMapping->getLabel();
             }
 

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -259,7 +259,7 @@ class ImportProcessingService
             $message = "Error processing element: {$importDataRowString}";
             $this->logger->error($message . $e);
 
-            $message . $e->getMessage();
+            $message .= $e->getMessage();
 
             if ($currentMapping !== null) {
                 $message .= "\nMapping Configuration: " . $currentMapping->getLabel();

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -183,6 +183,7 @@ class ImportProcessingService
     protected function processElement(string $configName, array $importDataRow, Resolver $resolver, array $mapping, int $userOwner)
     {
         $element = null;
+        $currentMapping = null;
         $importDataRowString = implode(', ', $this->flattenArray($importDataRow));
         try {
             //resolve data object
@@ -203,6 +204,7 @@ class ImportProcessingService
 
                     // extract raw data
                     $data = null;
+                    $currentMapping = $mappingConfiguration;
                     if (is_array($mappingConfiguration->getDataSourceIndex())) {
                         $data = [];
                         foreach ($mappingConfiguration->getDataSourceIndex() as $index) {
@@ -224,6 +226,7 @@ class ImportProcessingService
                     $dataTarget = $mappingConfiguration->getDataTarget();
                     $dataTarget->assignData($element, $data);
                 }
+                $currentMapping = null;
 
                 $event = new PreSaveEvent($configName, $importDataRow, $element);
                 $this->eventDispatcher->dispatch($event);
@@ -256,7 +259,11 @@ class ImportProcessingService
             $message = "Error processing element: {$importDataRowString}";
             $this->logger->error($message . $e);
 
-            $this->applicationLogger->error($message . $e->getMessage(), [
+            $message . $e->getMessage();
+
+            if ($currentMapping)  $message .= "\nMapping Configuration: " . $currentMapping->getLabel();
+
+            $this->applicationLogger->error($message, [
                 'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,
                 'fileObject' => new FileObject(json_encode($importDataRow)),
                 'relatedObject' => $element,

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -261,7 +261,9 @@ class ImportProcessingService
 
             $message . $e->getMessage();
 
-            if ($currentMapping)  $message .= "\nMapping Configuration: " . $currentMapping->getLabel();
+            if ($currentMapping) {
+                $message .= "\nMapping Configuration: " . $currentMapping->getLabel();
+            }
 
             $this->applicationLogger->error($message, [
                 'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -260,7 +260,8 @@ class ImportProcessingService
             $this->logger->error($message . $e);
 
             $message .= $e->getMessage();
-
+            // $currentMapping can be null before and after the loop above, but will have a value if it errors out during the loop
+            // @phpstan-ignore-next-line
             if ($currentMapping !== null) {
                 $message .= "\nMapping Configuration: " . $currentMapping->getLabel();
             }


### PR DESCRIPTION
Added logging for map configurations to easily identify which mapping configuration is throwing errors for hard to pinpoint errors such as the above, or "Undefined array key 1".

![image](https://github.com/user-attachments/assets/be35738d-37e1-4c67-aa68-3ede71b13590)

