### PR TITLE
fix memory leak

### DIFF
--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -19,7 +19,6 @@ use Doctrine\DBAL\Driver\Exception;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
-use Pimcore\Cache\RuntimeCache;
 use Pimcore\Console\AbstractCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -92,6 +92,7 @@ class SequentialProcessQueueCommand extends AbstractCommand
                 if (($i + 1) % 200 === 0) {
                     // Clear runtime cache so that pimcore memory usage does not go overboard 🫠
                     // https://github.com/pimcore/pimcore/issues/15866
+                    // https://docs.pimcore.com/platform/Pimcore/Objects/External_System_Interaction/#memory-issues
                     \Pimcore\RuntimeCache::clear();
                     \Pimcore::collectGarbage();
                 }

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -90,10 +90,7 @@ class SequentialProcessQueueCommand extends AbstractCommand
 
                 // call the garbage collector to avoid too many connections & memory issue
                 if (($i + 1) % 200 === 0) {
-                    // Clear runtime cache so that pimcore memory usage does not go overboard 🫠
-                    // https://github.com/pimcore/pimcore/issues/15866
-                    // https://docs.pimcore.com/platform/Pimcore/Objects/External_System_Interaction/#memory-issues
-                    \Pimcore\RuntimeCache::clear();
+                    \Pimcore\Cache\RuntimeCache::clear();
                     \Pimcore::collectGarbage();
                 }
             }

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -19,6 +19,7 @@ use Doctrine\DBAL\Driver\Exception;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
+use Pimcore\Cache\RuntimeCache;
 use Pimcore\Console\AbstractCommand;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputInterface;
@@ -90,6 +91,9 @@ class SequentialProcessQueueCommand extends AbstractCommand
 
                 // call the garbage collector to avoid too many connections & memory issue
                 if (($i + 1) % 200 === 0) {
+                    // Clear runtime cache so that pimcore memory usage does not go overboard 🫠
+                    // https://github.com/pimcore/pimcore/issues/15866
+                    \Pimcore\RuntimeCache::clear();
                     \Pimcore::collectGarbage();
                 }
             }


### PR DESCRIPTION
When executing the command to process and save objects sequentially, we discovered that Pimcore can encounter a memory leak.  
There is an existing issue that describes similar behavior:

* [Pimcore GitHub Issue #15866](https://github.com/pimcore/pimcore/issues/15866)

Additionally, Pimcore provides documentation on how to mitigate memory leaks in such cases:

* [Pimcore Docs: Preventing Memory Issues](https://docs.pimcore.com/platform/Pimcore/Objects/External_System_Interaction/#memory-issues)

Below is an example of the output **before** applying the suggested changes:
<img width="1791" alt="Screenshot 2025-04-07 at 11 57 44" src="https://github.com/user-attachments/assets/8643a36d-c1ea-44a0-a327-4c70a0a2e616" />