### PR TITLE
Fixed error handling in case of throwable

### DIFF
--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -252,7 +252,7 @@ class ImportProcessingService
                     'fileObject' => new FileObject(json_encode($importDataRow))
                 ]);
             }
-        } catch (\Exception | \TypeError $e) {
+        } catch (\Throwable $e) {
             $message = "Error processing element: {$importDataRowString}";
             $this->logger->error($message . $e);
 


### PR DESCRIPTION
Erroneous import data can lead to unexpected import behavior - causing errors, that currently won't be catched in the processElement function, as Exception will not catch every error. This causes the import process to constantly die. 

In our case it has been the `checkValidity` function of Data\QuantityValue that tried to call `getValue` on a string.

To ensure the error is catched and properly logged by the applicationlogger and give the customer the possibility to react, we simply catch Throwable instead.