### PR TITLE
feat: add type field collection for tranformation data type service

### DIFF
--- a/src/Mapping/Type/TransformationDataTypeService.php
+++ b/src/Mapping/Type/TransformationDataTypeService.php
@@ -65,6 +65,8 @@ class TransformationDataTypeService
 
     const COUNTRY_ARRAY = 'countryArray';
 
+    const FIELD_COLLECTION = 'fieldCollection';
+
     protected $transformationDataTypesMapping = [
         self::DEFAULT_TYPE => [
             'input',
@@ -152,6 +154,9 @@ class TransformationDataTypeService
         ],
         self::COUNTRY_ARRAY => [
             'countrymultiselect'
+        ],
+        self::FIELD_COLLECTION => [
+            'fieldcollections'
         ]
     ];
 


### PR DESCRIPTION
[**Issue**](https://github.com/pimcore/data-importer/issues/493)

Testing
Tested by extending transformation pipelines to handle FieldCollection types with nested array structures and confirmed successful data import into Pimcore objects.

Notes
This PR includes a simple UI configuration for FieldCollection mapping.

Maintains backward compatibility

### Evidence

**Class configure**
<img width="1048" alt="image" src="https://github.com/user-attachments/assets/1cd09f9b-e285-4599-b396-a3baa8cda395" />
**Mapping**
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/f9dabba6-53f4-4270-bd0d-2bc8787d7fc3" />
**Result**
<img width="1603" alt="image" src="https://github.com/user-attachments/assets/0fd607d7-e779-4260-a4a2-639e9e3e20fc" />

