### PR TITLE
fix: unable to write to system 'type' field

### DIFF
--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -152,7 +152,7 @@ class Direct implements DataTargetInterface
             $fieldName = $fieldNameParts[2];
         }
 
-        if ($this->fieldName === 'key') {
+        if ($this->fieldName === 'key' || $this->fieldName === 'type') {
             $currentDataIsEmpty = empty($currentData);
             $newDataIsEmpty = empty($newData);
         } else {


### PR DESCRIPTION
Resolves an issue where an Exception is thrown when trying to write to the SYSTEM type field

<img width="567" height="243" alt="image" src="https://github.com/user-attachments/assets/eb51a83b-e506-4256-8564-bb00bffa246d" />


<img width="610" height="430" alt="image" src="https://github.com/user-attachments/assets/52d2fddc-ca5e-428f-933f-47d71bf54ffe" />
