### PR TITLE
Feature: Extract Process Element Transformations

### DIFF
--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -263,10 +263,10 @@ class ImportProcessingService
     /**
      * Process transformations for an element
      * 
-     * @param ElementInterface $element
-     * @param array $importDataRow  
-     * @param MappingConfiguration[] $mapping
-     * @return MappingConfiguration|null Returns the mapping that was being processed.
+     * @param MappingConfiguration[] $mapping Array of mapping configurations.
+     * @param-out mixed &$currentMapping Output variable that will contain the current mapping.
+     * @throws \Throwable If the processing or a transformation fails
+     * @return void
      */
     public function processElementTransformations(
         ElementInterface $element,

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -265,8 +265,8 @@ class ImportProcessingService
      * 
      * @param MappingConfiguration[] $mapping Array of mapping configurations.
      * @param-out mixed &$currentMapping Output variable that will contain the current mapping.
+     *
      * @throws \Throwable If the processing or a transformation fails
-     * @return void
      */
     public function processElementTransformations(
         ElementInterface $element,

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -266,9 +266,14 @@ class ImportProcessingService
      * @param ElementInterface $element
      * @param array $importDataRow  
      * @param MappingConfiguration[] $mapping
-     * @return MappingConfiguration|null Returns the mapping that was being processed. Wrapped with a try/catch will allow user to view the last mapping being processed.
+     * @return MappingConfiguration|null Returns the mapping that was being processed.
      */
-    public function processElementTransformations(ElementInterface $element, array $importDataRow, array $mapping, &$currentMapping = null): void
+    public function processElementTransformations(
+        ElementInterface $element,
+        array $importDataRow,
+        array $mapping,
+        &$currentMapping = null
+    ): void
     {
         foreach ($mapping as $mappingConfiguration) {
             $currentMapping = $mappingConfiguration;

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -202,33 +202,7 @@ class ImportProcessingService
                     'relatedObject' => $element
                 ]);
 
-                foreach ($mapping as $mappingConfiguration) {
-
-                    // extract raw data
-                    $data = null;
-                    $currentMapping = $mappingConfiguration;
-                    if (is_array($mappingConfiguration->getDataSourceIndex())) {
-                        $data = [];
-                        foreach ($mappingConfiguration->getDataSourceIndex() as $index) {
-                            $data[] = $importDataRow[$index] ?? null;
-                        }
-
-                        if (count($data) === 1) {
-                            $data = $data[0];
-                        }
-                    } else {
-                        $data = $importDataRow[$mappingConfiguration->getDataSourceIndex()] ?? null;
-                    }
-
-                    // process pipeline
-                    foreach ($mappingConfiguration->getTransformationPipeline() as $operator) {
-                        $data = $operator->process($data);
-                    }
-
-                    $dataTarget = $mappingConfiguration->getDataTarget();
-                    $dataTarget->assignData($element, $data);
-                }
-                $currentMapping = null;
+                $this->processElementTransformations($element, $importDataRow, $mapping, $currentMapping);
 
                 $event = new PreSaveEvent($configName, $importDataRow, $element);
                 $this->eventDispatcher->dispatch($event);
@@ -284,6 +258,46 @@ class ImportProcessingService
                 'relatedObject' => $element,
             ]);
         }
+    }
+
+    /**
+     * Process transformations for an element
+     * 
+     * @param ElementInterface $element
+     * @param array $importDataRow  
+     * @param MappingConfiguration[] $mapping
+     * @return MappingConfiguration|null Returns the mapping that was being processed. Wrapped with a try/catch will allow user to view the last mapping being processed.
+     */
+    public function processElementTransformations(ElementInterface $element, array $importDataRow, array $mapping, &$currentMapping = null): void
+    {
+        foreach ($mapping as $mappingConfiguration) {
+            $currentMapping = $mappingConfiguration;
+            
+            // extract raw data
+            $data = null;
+            if (is_array($mappingConfiguration->getDataSourceIndex())) {
+                $data = [];
+                foreach ($mappingConfiguration->getDataSourceIndex() as $index) {
+                    $data[] = $importDataRow[$index] ?? null;
+                }
+
+                if (count($data) === 1) {
+                    $data = $data[0];
+                }
+            } else {
+                $data = $importDataRow[$mappingConfiguration->getDataSourceIndex()] ?? null;
+            }
+
+            // process pipeline
+            foreach ($mappingConfiguration->getTransformationPipeline() as $operator) {
+                $data = $operator->process($data);
+            }
+
+            $dataTarget = $mappingConfiguration->getDataTarget();
+            $dataTarget->assignData($element, $data);
+        }
+        
+        $currentMapping = null; // Success - clear current mapping
     }
 
     protected function cleanupElement(string $configName, string $identifier, Resolver $resolver, array $cleanupConfig)


### PR DESCRIPTION
The process element transformations were located within the process element function. This has been broken out into a separate function which allows the transformation logic to be used independently of the full element processing workflow.

We often need to apply transformations to elements and data outside the standard import process. By extracting and making a `processElementTransformations` function which can be called externally, we can reuse the transformation tools in any custom workflow.