### PR TITLE
Changed data column from TEXT to MEDIUMTEXT to accomodate larger data

### DIFF
--- a/src/Migrations/Version20251003105903.php
+++ b/src/Migrations/Version20251003105903.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pimcore\Bundle\DataImporterBundle\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
+use Pimcore\Migrations\BundleAwareMigration;
+
+final class Version20251003105903 extends BundleAwareMigration
+{
+    public function getDescription(): string
+    {
+        return 'Changes type of data column in data importer table from TEXT to MEDIUMTEXT to accommodate larger data entries.';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $queueTableName = QueueService::QUEUE_TABLE_NAME;
+        $this->addSql("
+            ALTER TABLE $queueTableName
+            MODIFY COLUMN `data` MEDIUMTEXT
+            CHARACTER SET utf8mb4
+            COLLATE utf8mb4_unicode_ci,
+            ALGORITHM=COPY;
+        ");
+    }
+
+    public function down(Schema $schema): void
+    {
+        $queueTableName = QueueService::QUEUE_TABLE_NAME;
+        $this->addSql("
+            ALTER TABLE $queueTableName
+            MODIFY COLUMN `data` TEXT
+            CHARACTER SET utf8mb4
+            COLLATE utf8mb4_unicode_ci,
+            ALGORITHM=COPY;
+        ");
+    }
+
+    protected function getBundleName(): string
+    {
+        return 'PimcoreDataImporterBundle';
+    }
+}

--- a/src/Migrations/Version20251003105903.php
+++ b/src/Migrations/Version20251003105903.php
@@ -18,6 +18,10 @@ final class Version20251003105903 extends BundleAwareMigration
     public function up(Schema $schema): void
     {
         $queueTableName = QueueService::QUEUE_TABLE_NAME;
+        if (!$schema->hasTable($queueTableName)) {
+            return;
+        }
+
         $this->addSql("
             ALTER TABLE $queueTableName
             MODIFY COLUMN `data` MEDIUMTEXT
@@ -30,6 +34,10 @@ final class Version20251003105903 extends BundleAwareMigration
     public function down(Schema $schema): void
     {
         $queueTableName = QueueService::QUEUE_TABLE_NAME;
+        if (!$schema->hasTable($queueTableName)) {
+            return;
+        }
+
         $this->addSql("
             ALTER TABLE $queueTableName
             MODIFY COLUMN `data` TEXT

--- a/src/Queue/QueueService.php
+++ b/src/Queue/QueueService.php
@@ -88,7 +88,7 @@ class QueueService
             userOwner int unsigned NOT NULL DEFAULT 0,
 
             configName varchar(80) NULL,
-            `data` TEXT null,
+            `data` MEDIUMTEXT null,
             executionType varchar(20) NULL,
             jobType varchar(20) NULL,
             dispatched bigint NULL,


### PR DESCRIPTION
**Context:**
TEXT	65,535 bytes
MEDIUMTEXT	16,777,215 bytes

Changing the data-type to MEDIUMTEXT is crucial to allow larger data to be imported. E.g. lot's of specifications-text