### PR TITLE
Only log and save in the cleanup when data objects were modiffied

### DIFF
--- a/src/Cleanup/CleanupStrategyInterface.php
+++ b/src/Cleanup/CleanupStrategyInterface.php
@@ -19,5 +19,5 @@ interface CleanupStrategyInterface
     /**
      * Apply cleanup on given element
      */
-    public function doCleanup(ElementInterface $element): void;
+    public function doCleanup(ElementInterface $element): bool;
 }

--- a/src/Cleanup/DeleteStrategy.php
+++ b/src/Cleanup/DeleteStrategy.php
@@ -16,8 +16,9 @@ use Pimcore\Model\Element\ElementInterface;
 
 class DeleteStrategy implements CleanupStrategyInterface
 {
-    public function doCleanup(ElementInterface $element): void
+    public function doCleanup(ElementInterface $element): bool
     {
         $element->delete();
+        return true;
     }
 }

--- a/src/Cleanup/UnpublishStrategy.php
+++ b/src/Cleanup/UnpublishStrategy.php
@@ -16,11 +16,14 @@ use Pimcore\Model\Element\ElementInterface;
 
 class UnpublishStrategy implements CleanupStrategyInterface
 {
-    public function doCleanup(ElementInterface $element): void
+    public function doCleanup(ElementInterface $element): bool
     {
-        if (method_exists($element, 'setPublished')) {
-            $element->setPublished(false);
-            $element->save();
+        if (!method_exists($element, 'setPublished') || !method_exists($element, 'isPublished') ||
+            !$element->isPublished()) {
+            return false;
         }
+        $element->setPublished(false);
+        $element->save();
+        return true;
     }
 }

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -349,28 +349,31 @@ class ImportProcessingService
 
     protected function cleanupElement(string $configName, string $identifier, Resolver $resolver, array $cleanupConfig)
     {
-        if ($cleanupConfig['doCleanup'] ?? false) {
-            $element = null;
-
-            try {
-                $element = $resolver->loadElementByIdentifier($identifier);
-                if ($element) {
-                    $cleanupStrategy = $this->cleanupStrategyFactory->loadCleanupStrategy($cleanupConfig['strategy']);
-                    $cleanupStrategy->doCleanup($element);
-
-                    $message = "Element {$identifier} cleaned up ({$cleanupConfig['strategy']}) successfully.";
-                    $this->logInfo($configName, $message, [
-                        'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,
-                        'relatedObject' => $element
-                    ]);
-                }
-            } catch (\Exception $e) {
-                $message = 'Error cleaning up element: ';
-                $this->logError($configName, $message . $e->getMessage(), [
-                    'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,
-                    'relatedObject' => $element,
-                ]);
+        if (!($cleanupConfig['doCleanup'] ?? false)) {
+            return;
+        }
+        try {
+            $element = $resolver->loadElementByIdentifier($identifier);
+            if ($element === null) {
+                return;
             }
+            $cleanupStrategy = $this->cleanupStrategyFactory->loadCleanupStrategy($cleanupConfig['strategy']);
+            if ($cleanupStrategy->doCleanup($element) === false) {
+                return;
+            }
+            $message = "Element {$identifier} cleaned up ({$cleanupConfig['strategy']}) successfully.";
+            $this->logger->info($message);
+            $this->applicationLogger->info($message, [
+                'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,
+                'relatedObject' => $element
+            ]);
+        } catch (\Exception $e) {
+            $message = 'Error cleaning up element: ';
+            $this->logger->error($message . $e);
+            $this->applicationLogger->error($message . $e->getMessage(), [
+                'component' => PimcoreDataImporterBundle::LOGGER_COMPONENT_PREFIX . $configName,
+                'relatedObject' => $element,
+            ]);
         }
     }
 


### PR DESCRIPTION
When configuring a cleanup method in the DataHub importer, the `cleanupElement` function emits a log message for every stored object of the imported type that wasn't in the feed. For large amounts of data, this makes the logs harder to use, and these log messages are not very informative. It would be good to reduce the number of log messages.

Another improvement: The `UnpublishStrategy` currently saves every element it receives, but it should only save elements whose publication state it changes.