### PR TITLE
[Bug, EC] PEES-924: Replace http.InvalidArgumentException with InvalidArgumentException

### DIFF
--- a/src/Controller/ConfigDataObjectController.php
+++ b/src/Controller/ConfigDataObjectController.php
@@ -14,7 +14,7 @@ namespace Pimcore\Bundle\DataImporterBundle\Controller;
 
 use Cron\CronExpression;
 use Exception;
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use League\Flysystem\FilesystemOperator;
 use Pimcore\Bundle\AdminBundle\Helper\QueryParams;
 use Pimcore\Bundle\DataHubBundle\Configuration;


### PR DESCRIPTION
Otherwise we have a dependency on the pecl_http extension.

Resolves https://github.com/pimcore/service-operations/issues/323