### PR TITLE
Change pull_request to pull_request_target in workflow

### DIFF
--- a/.github/workflows/codeception.yml
+++ b/.github/workflows/codeception.yml
@@ -9,7 +9,7 @@ on:
             - "[0-9]+.[0-9]+"
             - "[0-9]+.x"
             - "feature-*"
-    pull_request:
+    pull_request_target:
         types: [opened, synchronize, reopened]
 
 env:

--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: '0 3 * * 1,3,5'
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [ opened, synchronize, reopened ]
     paths-ignore:
       - 'assets/**'


### PR DESCRIPTION
This pull request makes a small but important update to the GitHub Actions workflow trigger configuration. The workflow now uses `pull_request_target` instead of `pull_request`, which changes the permissions and context under which the workflow runs.

- Workflow trigger updated from `pull_request` to `pull_request_target` in `.github/workflows/codeception.yml` to allow the workflow to run with access to secrets and the base repository context on pull requests from forks.