### PR TITLE
[Bug, EC] PEES-924: Replace http InvalidArgumentException with global one

### DIFF
--- a/src/Controller/ConfigDataObjectController.php
+++ b/src/Controller/ConfigDataObjectController.php
@@ -14,7 +14,7 @@ namespace Pimcore\Bundle\DataImporterBundle\Controller;
 
 use Cron\CronExpression;
 use Exception;
-use http\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 use League\Flysystem\FilesystemOperator;
 use Pimcore\Bundle\AdminBundle\Helper\QueryParams;
 use Pimcore\Bundle\DataHubBundle\Configuration;


### PR DESCRIPTION
If PECL `ext-http` is not installed, it would be breaking. It was also not required https://github.com/pimcore/data-importer/blob/319befee14ccb6559c9dbeb977567b9834692716/composer.json#L17-L18
I believe IDE autocomplete opted for that inadvertently on 
https://github.com/pimcore/data-importer/commit/018a2a170d3cb5f12572db6226282051178b5a30#diff-5cb3450c1ac9c52e7ddfc6722471105e322b492b607c0b64e12ca4ab22621298R20 instead of the PHP global one