### PR TITLE
Static analysis fix

### DIFF
--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
           MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '($php_versions | split(",")) as $versions | { include: [ .configs[] | select(.php_version | IN($versions[])) | .matrix[] ] }')
           ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
           echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -78,7 +78,7 @@ jobs:
 
   static-analysis:
     needs: setup-matrix
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@reusable-workflows
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-static-analysis-unified.yaml@main
     with:
       phpstan_matrix: ${{ needs.setup-matrix.outputs.phpstan_matrix }}
       private_repo: ${{ needs.setup-matrix.outputs.private_repo }}

--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -68,7 +68,7 @@ jobs:
         run: |
           php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
           MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
-          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '($php_versions | split(",")) as $versions | { include: [ .configs[] | select(.php_version | IN($versions[])) | .matrix[] ] }')
+          FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
           ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
           echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/new-static-analysis.yaml
+++ b/.github/workflows/new-static-analysis.yaml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: pimcore/workflows-collection-public
-          ref: reusable-workflows
+          ref: main
           path: reusable-workflows
 
       - name: Parse PHP versions from composer.json
@@ -69,6 +69,10 @@ jobs:
           php_versions="${{ steps.parse-php-versions.outputs.php_versions }}"
           MATRIX_JSON=$(cat reusable-workflows/phpstan-configuration/matrix-config.json)
           FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq --arg php_versions "$php_versions" '{ include: [ .configs[] | select(.php_version == $php_versions) | .matrix[] ] }')
+          if [ "$(echo "$FILTERED_MATRIX_JSON" | jq '.include | length')" -eq 0 ]; then
+            echo "No exact match for php_versions=$php_versions, falling back to default"
+            FILTERED_MATRIX_JSON=$(echo "$MATRIX_JSON" | jq '{ include: [ .configs[] | select(.php_version == "default") | .matrix[] ] }')
+          fi
           ENCODED_MATRIX_JSON=$(echo "$FILTERED_MATRIX_JSON" | jq -c .)
           echo "phpstan_matrix=$ENCODED_MATRIX_JSON" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
This pull request updates the static analysis workflow configuration to improve reliability and ensure the correct workflow and matrix configuration are used. The main changes update references to the correct branch and add a fallback mechanism for PHP version matrix selection.

**Workflow reference updates:**

* Changed the `ref` for the `pimcore/workflows-collection-public` repository from `reusable-workflows` to `main` in both the `checkout` and workflow usage steps in `.github/workflows/new-static-analysis.yaml`. [[1]](diffhunk://#diff-1d7e30699b648eda2236a891d3e9f486dd9ee2e0220dab98886fe5e20eab5178L49-R49) [[2]](diffhunk://#diff-1d7e30699b648eda2236a891d3e9f486dd9ee2e0220dab98886fe5e20eab5178R72-R81)

**Matrix configuration improvements:**

* Added a fallback to use the `default` PHP version matrix if there is no exact match for the parsed PHP versions in the matrix configuration. This ensures the workflow does not fail if a specific PHP version is not found.