### PR TITLE
[Improvement] Remove ?queue_name= from transport DSN for concatenation support

### DIFF
--- a/src/Resources/config/pimcore/config.yml
+++ b/src/Resources/config/pimcore/config.yml
@@ -16,7 +16,7 @@ framework:
     messenger:
         transports:
             pimcore_data_import:
-                dsn: '%pimcore.messenger.transport_dsn%?queue_name=pimcore_data_import'
+                dsn: '%pimcore.messenger.transport_dsn%pimcore_data_import'
 
         routing:
             'Pimcore\Bundle\DataImporterBundle\Messenger\DataImporterMessage': pimcore_data_import


### PR DESCRIPTION
## Summary

Updates the messenger transport DSN to use parameter concatenation instead of hardcoded `?queue_name=` query string. The queue name separator is now part of the `PIMCORE_MESSENGER_TRANSPORT_DSN` env var, enabling support for AMQP and Redis transport backends without code changes.

## Changes

- Remove `?queue_name=` from `pimcore_data_importer` transport DSN
- Transport now uses: `"%pimcore.messenger.transport_dsn%pimcore_data_importer"`

## Related

- Core PR: https://github.com/pimcore/pimcore/pull/19038
- Tracking ticket: https://github.com/pimcore/product-management/issues/1148