### PR TITLE
[Improvement] Rename PIMCORE_MESSENGER_TRANSPORT_DSN to PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX

### DIFF
--- a/doc/03_Upgrade.md
+++ b/doc/03_Upgrade.md
@@ -1,7 +1,7 @@
 # Update Notes
 
 ## Upgrade to 2026.1.0
-- The messenger transport DSN is now configurable via the `%pimcore.messenger.transport_dsn%` container parameter instead of being hardcoded to `doctrine://default`. This allows the installer to wire the transport DSN from environment variables (e.g. `PIMCORE_MESSENGER_TRANSPORT_DSN`).
+- The messenger transport DSN is now configurable via the `%pimcore.messenger.transport_dsn_prefix%` container parameter instead of being hardcoded to `doctrine://default`. This allows the installer to wire the transport DSN from environment variables (e.g. `PIMCORE_MESSENGER_TRANSPORT_DSN_PREFIX`).
 - Added support to `PHP` `8.5`.
 - Removed support to `PHP` `8.3` and Symfony `v6`.
 - Change namespave from `Pimcore\Log\ApplicationLogger` to `Pimcore\Bundle\ApplicationLoggerBundle\ApplicationLogger`

--- a/src/Resources/config/pimcore/config.yml
+++ b/src/Resources/config/pimcore/config.yml
@@ -16,7 +16,7 @@ framework:
     messenger:
         transports:
             pimcore_data_import:
-                dsn: '%pimcore.messenger.transport_dsn%pimcore_data_import'
+                dsn: '%pimcore.messenger.transport_dsn_prefix%pimcore_data_import'
 
         routing:
             'Pimcore\Bundle\DataImporterBundle\Messenger\DataImporterMessage': pimcore_data_import


### PR DESCRIPTION
## Summary

- Renames `%pimcore.messenger.transport_dsn%` to `%pimcore.messenger.transport_dsn_prefix%` in messenger transport config
- Updates upgrade notes to reflect the new env var and parameter names

Companion to pimcore/pimcore core rename PR.

Ref: https://github.com/pimcore/product-management/issues/1148