### PR TITLE
Apply @internal, final annotations and PHP 8 modernization

### DIFF
--- a/src/Cleanup/CleanupStrategyFactory.php
+++ b/src/Cleanup/CleanupStrategyFactory.php
@@ -14,21 +14,19 @@ namespace Pimcore\Bundle\DataImporterBundle\Cleanup;
 
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 
-class CleanupStrategyFactory
+/**
+ * @internal
+ */
+final class CleanupStrategyFactory
 {
-    /**
-     * @var CleanupStrategyInterface[]
-     */
-    protected $cleanupStrategies;
-
     /**
      * CleanupStrategyFactory constructor.
      *
      * @param CleanupStrategyInterface[] $cleanupStrategies
      */
-    public function __construct(array $cleanupStrategies)
-    {
-        $this->cleanupStrategies = $cleanupStrategies;
+    public function __construct(
+        private readonly array $cleanupStrategies,
+    ) {
     }
 
     /**

--- a/src/Cleanup/DeleteStrategy.php
+++ b/src/Cleanup/DeleteStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Cleanup;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class DeleteStrategy implements CleanupStrategyInterface
+/**
+ * @internal
+ */
+final class DeleteStrategy implements CleanupStrategyInterface
 {
     public function doCleanup(ElementInterface $element): void
     {

--- a/src/Cleanup/UnpublishStrategy.php
+++ b/src/Cleanup/UnpublishStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Cleanup;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class UnpublishStrategy implements CleanupStrategyInterface
+/**
+ * @internal
+ */
+final class UnpublishStrategy implements CleanupStrategyInterface
 {
     public function doCleanup(ElementInterface $element): void
     {

--- a/src/Command/CronExecutionCommand.php
+++ b/src/Command/CronExecutionCommand.php
@@ -19,17 +19,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class CronExecutionCommand extends AbstractCommand
+/**
+ * @internal
+ */
+final class CronExecutionCommand extends AbstractCommand
 {
-    /**
-     * @var ImportPreparationService
-     */
-    protected $importPreparationService;
-
-    public function __construct(ImportPreparationService $importPreparationService)
-    {
+    public function __construct(
+        private readonly ImportPreparationService $importPreparationService,
+    ) {
         parent::__construct();
-        $this->importPreparationService = $importPreparationService;
     }
 
     protected function configure(): void

--- a/src/Command/DummyDataCommand.php
+++ b/src/Command/DummyDataCommand.php
@@ -196,12 +196,12 @@ final class DummyDataCommand extends AbstractCommand
 
     /**
      * @param array $data
-     * @param \SimpleXMLElement $xml_data
+     * @param \SimpleXMLElement $xmlData
      * @param string $firstLevelKey
      *
      * @return void
      */
-    private function arrayToXml($data, &$xml_data, $firstLevelKey = null)
+    private function arrayToXml($data, &$xmlData, $firstLevelKey = null)
     {
         foreach ($data as $key => $value) {
             $elementName = $key;
@@ -213,10 +213,10 @@ final class DummyDataCommand extends AbstractCommand
             }
 
             if (is_array($value)) {
-                $subnode = $xml_data->addChild($elementName);
+                $subnode = $xmlData->addChild($elementName);
                 $this->arrayToXml($value, $subnode);
             } else {
-                $xml_data->addChild($elementName, htmlspecialchars($value));
+                $xmlData->addChild($elementName, htmlspecialchars($value));
             }
         }
     }

--- a/src/Command/DummyDataCommand.php
+++ b/src/Command/DummyDataCommand.php
@@ -20,7 +20,10 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
-class DummyDataCommand extends AbstractCommand
+/**
+ * @internal
+ */
+final class DummyDataCommand extends AbstractCommand
 {
     protected function configure(): void
     {
@@ -156,7 +159,7 @@ class DummyDataCommand extends AbstractCommand
         return 0;
     }
 
-    protected function writeCsv(string $filename, array $data)
+    private function writeCsv(string $filename, array $data)
     {
         $fp = fopen($filename, 'w');
 
@@ -177,7 +180,7 @@ class DummyDataCommand extends AbstractCommand
         fclose($fp);
     }
 
-    protected function writeXml(string $filename, array $data)
+    private function writeXml(string $filename, array $data)
     {
         array_shift($data);
 
@@ -198,7 +201,7 @@ class DummyDataCommand extends AbstractCommand
      *
      * @return void
      */
-    public function arrayToXml($data, &$xml_data, $firstLevelKey = null)
+    private function arrayToXml($data, &$xml_data, $firstLevelKey = null)
     {
         foreach ($data as $key => $value) {
             $elementName = $key;
@@ -218,7 +221,7 @@ class DummyDataCommand extends AbstractCommand
         }
     }
 
-    protected function writeJson(string $filename, array $data)
+    private function writeJson(string $filename, array $data)
     {
         array_shift($data);
         $json = json_encode($data);

--- a/src/Command/ParallelProcessQueueCommand.php
+++ b/src/Command/ParallelProcessQueueCommand.php
@@ -17,23 +17,16 @@ use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ParallelProcessQueueCommand extends ParallelizationAbstractCommand
+/**
+ * @internal
+ */
+final class ParallelProcessQueueCommand extends ParallelizationAbstractCommand
 {
-    /**
-     * @var ImportProcessingService
-     */
-    protected $importProcessingService;
-
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
-
-    public function __construct(ImportProcessingService $importProcessingService, QueueService $queueService)
-    {
+    public function __construct(
+        private readonly ImportProcessingService $importProcessingService,
+        private readonly QueueService $queueService,
+    ) {
         parent::__construct();
-        $this->importProcessingService = $importProcessingService;
-        $this->queueService = $queueService;
     }
 
     protected function configure(): void

--- a/src/Command/ParallelizationAbstractCommand.php
+++ b/src/Command/ParallelizationAbstractCommand.php
@@ -17,6 +17,9 @@ use Pimcore\Console\Traits\Parallelization;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+/**
+ * @internal
+ */
 abstract class ParallelizationAbstractCommand extends AbstractCommand
 {
     use Parallelization

--- a/src/Command/PrepareImportCommand.php
+++ b/src/Command/PrepareImportCommand.php
@@ -18,22 +18,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PrepareImportCommand extends AbstractCommand
+/**
+ * @internal
+ */
+final class PrepareImportCommand extends AbstractCommand
 {
-    /**
-     * @var ImportPreparationService
-     */
-    protected $importPreparationService;
-
-    /**
-     * PrepareImportCommand constructor.
-     *
-     * @param ImportPreparationService $importPreparationService
-     */
-    public function __construct(ImportPreparationService $importPreparationService)
-    {
+    public function __construct(
+        private readonly ImportPreparationService $importPreparationService,
+    ) {
         parent::__construct();
-        $this->importPreparationService = $importPreparationService;
     }
 
     protected function configure(): void

--- a/src/Command/SequentialProcessQueueCommand.php
+++ b/src/Command/SequentialProcessQueueCommand.php
@@ -23,28 +23,18 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Lock\LockFactory;
 use Symfony\Component\Lock\LockInterface;
 
-class SequentialProcessQueueCommand extends AbstractCommand
+/**
+ * @internal
+ */
+final class SequentialProcessQueueCommand extends AbstractCommand
 {
-    /**
-     * @var ImportProcessingService
-     */
-    protected $importProcessingService;
+    private ?LockInterface $lock = null;
 
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
-
-    /**
-     * @var LockInterface|null
-     */
-    private $lock;
-
-    public function __construct(ImportProcessingService $importProcessingService, QueueService $queueService)
-    {
+    public function __construct(
+        private readonly ImportProcessingService $importProcessingService,
+        private readonly QueueService $queueService,
+    ) {
         parent::__construct();
-        $this->importProcessingService = $importProcessingService;
-        $this->queueService = $queueService;
     }
 
     public function configure(): void

--- a/src/Controller/ConfigDataObjectController.php
+++ b/src/Controller/ConfigDataObjectController.php
@@ -40,8 +40,11 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Attribute\Route;
 
+/**
+ * @internal
+ */
 #[Route('/admin/pimcoredataimporter/dataobject/config')]
-class ConfigDataObjectController extends UserAwareController
+final class ConfigDataObjectController extends UserAwareController
 {
     use JsonHelperTrait;
 
@@ -49,21 +52,10 @@ class ConfigDataObjectController extends UserAwareController
 
     private const CONFIG_DOES_NOT_EXIST_MSG = 'Configuration %s does not exist.';
 
-    /**
-     * @var PreviewService
-     */
-    protected $previewService;
-
-    /**
-     * ConfigDataObjectController constructor.
-     *
-     * @param PreviewService $previewService
-     */
     public function __construct(
         private readonly DataTypeServiceInterface $dataTypeService,
-        PreviewService $previewService
+        private readonly PreviewService $previewService,
     ) {
-        $this->previewService = $previewService;
     }
 
     /**
@@ -118,7 +110,7 @@ class ConfigDataObjectController extends UserAwareController
      *
      * @return array
      */
-    protected function loadAvailableColumnHeaders(
+    private function loadAvailableColumnHeaders(
         string $configName,
         array $config,
         InterpreterFactory $interpreterFactory
@@ -144,7 +136,7 @@ class ConfigDataObjectController extends UserAwareController
         return [];
     }
 
-    protected function isValidJson(array $array): bool
+    private function isValidJson(array $array): bool
     {
         json_encode($array);
 
@@ -706,7 +698,7 @@ class ConfigDataObjectController extends UserAwareController
      *
      * @throws Exception
      */
-    protected function getImportFilePath(string $configName): string
+    private function getImportFilePath(string $configName): string
     {
         $configuration = Configuration::getByName($configName);
         if (!$configuration) {

--- a/src/Controller/ConfigDataObjectController.php
+++ b/src/Controller/ConfigDataObjectController.php
@@ -62,7 +62,7 @@ final class ConfigDataObjectController extends UserAwareController
      * @throws Exception
      */
     #[Route('/save')]
-    public function saveAction(Request $request): ?JsonResponse
+    public function saveAction(Request $request): JsonResponse
     {
         $this->checkPermission(self::CONFIG_NAME);
 

--- a/src/DataSource/Interpreter/AbstractInterpreter.php
+++ b/src/DataSource/Interpreter/AbstractInterpreter.php
@@ -23,77 +23,37 @@ use Pimcore\Model\Tool\TmpStore;
 use Pimcore\Tool\Admin;
 use Psr\Log\LoggerAwareTrait;
 
+/**
+ * @internal
+ */
 abstract class AbstractInterpreter implements InterpreterInterface
 {
     use LoggerAwareTrait;
 
-    /**
-     * @var DeltaChecker
-     */
-    protected $deltaChecker;
+    protected string $configName;
 
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
+    protected bool $doDeltaCheck;
 
-    /**
-     * @var ApplicationLogger
-     */
-    protected $applicationLogger;
+    protected mixed $idDataIndex;
 
-    /**
-     * @var string
-     */
-    protected $configName;
+    protected string $executionType;
 
-    /**
-     * @var bool
-     */
-    protected $doDeltaCheck;
+    protected bool $doCleanup;
 
-    /**
-     * @var mixed
-     */
-    protected $idDataIndex;
+    protected bool $doArchiveImportFile;
 
-    /**
-     * @var string
-     */
-    protected $executionType;
-
-    /**
-     * @var bool
-     */
-    protected $doCleanup;
-
-    /**
-     * @var bool
-     */
-    protected $doArchiveImportFile;
-
-    /**
-     * @var Resolver
-     */
-    protected $resolver;
+    protected Resolver $resolver;
 
     /**
      * @var string[]
      */
-    protected $identifierCache;
+    protected array $identifierCache;
 
-    /**
-     * AbstractInterpreter constructor.
-     *
-     * @param DeltaChecker $deltaChecker
-     * @param QueueService $queueService
-     * @param ApplicationLogger $applicationLogger
-     */
-    public function __construct(DeltaChecker $deltaChecker, QueueService $queueService, ApplicationLogger $applicationLogger)
-    {
-        $this->deltaChecker = $deltaChecker;
-        $this->queueService = $queueService;
-        $this->applicationLogger = $applicationLogger;
+    public function __construct(
+        protected readonly DeltaChecker $deltaChecker,
+        protected readonly QueueService $queueService,
+        protected readonly ApplicationLogger $applicationLogger,
+    ) {
     }
 
     public function getConfigName(): string

--- a/src/DataSource/Interpreter/CsvFileInterpreter.php
+++ b/src/DataSource/Interpreter/CsvFileInterpreter.php
@@ -16,31 +16,22 @@ use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 use Pimcore\Version;
 use Symfony\Component\Mime\MimeTypes;
 
-class CsvFileInterpreter extends AbstractInterpreter
+/**
+ * @internal
+ */
+final class CsvFileInterpreter extends AbstractInterpreter
 {
     private const UTF8_BOM = "\xEF\xBB\xBF";
 
-    /**
-     * @var bool
-     */
-    protected $skipFirstRow;
+    private bool $skipFirstRow;
 
-    protected bool $saveHeaderName;
+    private bool $saveHeaderName;
 
-    /**
-     * @var string
-     */
-    protected $delimiter;
+    private string $delimiter;
 
-    /**
-     * @var string
-     */
-    protected $enclosure;
+    private string $enclosure;
 
-    /**
-     * @var string
-     */
-    protected $escape;
+    private string $escape;
 
     protected function doInterpretFileAndCallProcessRow(string $path): void
     {

--- a/src/DataSource/Interpreter/DeltaChecker/DeltaChecker.php
+++ b/src/DataSource/Interpreter/DeltaChecker/DeltaChecker.php
@@ -16,18 +16,16 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 
-class DeltaChecker
+/**
+ * @internal
+ */
+final class DeltaChecker
 {
-    /**
-     * @var Connection
-     */
-    protected $db;
+    private const CACHE_TABLE_NAME = 'bundle_data_hub_data_importer_delta_cache';
 
-    const CACHE_TABLE_NAME = 'bundle_data_hub_data_importer_delta_cache';
-
-    public function __construct(Connection $connection)
-    {
-        $this->db = $connection;
+    public function __construct(
+        private readonly Connection $db,
+    ) {
     }
 
     /**
@@ -37,7 +35,7 @@ class DeltaChecker
      *
      * @throws Exception
      */
-    protected function createTableIfNotExisting(?\Closure $callable = null)
+    private function createTableIfNotExisting(?\Closure $callable = null)
     {
         $this->db->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (
             configName varchar(80) NOT NULL,
@@ -53,7 +51,7 @@ class DeltaChecker
         return null;
     }
 
-    protected function getCurrentHash(string $configName, string $id): string
+    private function getCurrentHash(string $configName, string $id): string
     {
         try {
             return $this->db->fetchOne(
@@ -67,7 +65,7 @@ class DeltaChecker
         }
     }
 
-    protected function updateHash(string $configName, string $id, string $hash)
+    private function updateHash(string $configName, string $id, string $hash)
     {
         try {
             $this->db->executeQuery(

--- a/src/DataSource/Interpreter/InterpreterFactory.php
+++ b/src/DataSource/Interpreter/InterpreterFactory.php
@@ -16,21 +16,17 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Resolver;
 
-class InterpreterFactory
+/**
+ * @internal
+ */
+final class InterpreterFactory
 {
     /**
-     * @var InterpreterInterface[]
-     */
-    protected $interpreterBluePrints;
-
-    /**
-     * LoaderFactory constructor.
-     *
      * @param InterpreterInterface[] $interpreterBluePrints
      */
-    public function __construct(array $interpreterBluePrints)
-    {
-        $this->interpreterBluePrints = $interpreterBluePrints;
+    public function __construct(
+        private readonly array $interpreterBluePrints,
+    ) {
     }
 
     /**

--- a/src/DataSource/Interpreter/JsonFileInterpreter.php
+++ b/src/DataSource/Interpreter/JsonFileInterpreter.php
@@ -19,19 +19,16 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\PimcoreDataImporterBundle;
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 
+/**
+ * @internal
+ */
 class JsonFileInterpreter extends AbstractInterpreter
 {
     protected string $path;
 
-    /**
-     * @var array|null
-     */
-    protected $cachedContent = null;
+    protected ?array $cachedContent = null;
 
-    /**
-     * @var string|null
-     */
-    protected $cachedFilePath = null;
+    protected ?string $cachedFilePath = null;
 
     protected function loadDataRaw(string $path): array
     {

--- a/src/DataSource/Interpreter/SqlFileInterpreter.php
+++ b/src/DataSource/Interpreter/SqlFileInterpreter.php
@@ -14,6 +14,9 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 
-class SqlFileInterpreter extends JsonFileInterpreter
+/**
+ * @internal
+ */
+final class SqlFileInterpreter extends JsonFileInterpreter
 {
 }

--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -15,17 +15,14 @@ namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 
-class XlsxFileInterpreter extends AbstractInterpreter
+/**
+ * @internal
+ */
+final class XlsxFileInterpreter extends AbstractInterpreter
 {
-    /**
-     * @var bool
-     */
-    protected $skipFirstRow;
+    private bool $skipFirstRow;
 
-    /**
-     * @var string
-     */
-    protected $sheetName;
+    private string $sheetName;
 
     protected function doInterpretFileAndCallProcessRow(string $path): void
     {

--- a/src/DataSource/Interpreter/XmlFileInterpreter.php
+++ b/src/DataSource/Interpreter/XmlFileInterpreter.php
@@ -24,7 +24,7 @@ use Symfony\Component\Config\Util\XmlUtils;
  */
 final class XmlFileInterpreter extends AbstractInterpreter
 {
-    private ?string $xpath;
+    private string $xpath;
 
     private ?string $schema;
 

--- a/src/DataSource/Interpreter/XmlFileInterpreter.php
+++ b/src/DataSource/Interpreter/XmlFileInterpreter.php
@@ -19,29 +19,20 @@ use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 use Symfony\Component\Config\Util\Exception\XmlParsingException;
 use Symfony\Component\Config\Util\XmlUtils;
 
-class XmlFileInterpreter extends AbstractInterpreter
+/**
+ * @internal
+ */
+final class XmlFileInterpreter extends AbstractInterpreter
 {
-    /**
-     * @var string|null
-     */
-    protected $xpath;
+    private ?string $xpath;
 
-    /**
-     * @var string|null
-     */
-    protected $schema;
+    private ?string $schema;
 
-    /**
-     * @var \DOMDocument|null
-     */
-    protected $cachedContent = null;
+    private ?\DOMDocument $cachedContent = null;
 
-    /**
-     * @var string|null
-     */
-    protected $cachedFilePath = null;
+    private ?string $cachedFilePath = null;
 
-    protected function loadDataRaw(string $path)
+    private function loadDataRaw(string $path)
     {
         $schema = $this->schema;
 
@@ -61,7 +52,7 @@ class XmlFileInterpreter extends AbstractInterpreter
      *
      * @throws InvalidInputException
      */
-    protected function loadData(string $path)
+    private function loadData(string $path)
     {
         if ($this->cachedFilePath !== $path || !empty($this->cachedContent)) {
             $dom = $this->loadDataRaw($path);

--- a/src/DataSource/Loader/AssetLoader.php
+++ b/src/DataSource/Loader/AssetLoader.php
@@ -15,17 +15,14 @@ namespace Pimcore\Bundle\DataImporterBundle\DataSource\Loader;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Asset;
 
-class AssetLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class AssetLoader implements DataLoaderInterface
 {
-    /**
-     * @var string
-     */
-    protected $assetPath;
+    private string $assetPath;
 
-    /**
-     * @var string
-     */
-    protected $temporaryFile = null;
+    private ?string $temporaryFile = null;
 
     public function loadData(): string
     {

--- a/src/DataSource/Loader/DataLoaderFactory.php
+++ b/src/DataSource/Loader/DataLoaderFactory.php
@@ -14,21 +14,17 @@ namespace Pimcore\Bundle\DataImporterBundle\DataSource\Loader;
 
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 
-class DataLoaderFactory
+/**
+ * @internal
+ */
+final class DataLoaderFactory
 {
     /**
-     * @var DataLoaderInterface[]
-     */
-    protected $dataLoaderBluePrints;
-
-    /**
-     * DataLoaderFactory constructor.
-     *
      * @param DataLoaderInterface[] $dataLoaderBluePrints
      */
-    public function __construct(array $dataLoaderBluePrints)
-    {
-        $this->dataLoaderBluePrints = $dataLoaderBluePrints;
+    public function __construct(
+        private readonly array $dataLoaderBluePrints,
+    ) {
     }
 
     /**

--- a/src/DataSource/Loader/HttpLoader.php
+++ b/src/DataSource/Loader/HttpLoader.php
@@ -16,25 +16,19 @@ use Exception;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Symfony\Component\Filesystem\Filesystem;
 
-class HttpLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class HttpLoader implements DataLoaderInterface
 {
-    /**
-     * @var string
-     */
-    protected $url;
+    private string $url;
 
-    /**
-     * @var string
-     */
-    protected $schema;
+    private string $schema;
 
-    /**
-     * @var string
-     */
-    protected $importFilePath;
+    private string $importFilePath;
 
     public function __construct(
-        protected Filesystem $filesystem
+        private readonly Filesystem $filesystem,
     ) {
     }
 

--- a/src/DataSource/Loader/PushLoader.php
+++ b/src/DataSource/Loader/PushLoader.php
@@ -15,25 +15,19 @@ namespace Pimcore\Bundle\DataImporterBundle\DataSource\Loader;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Symfony\Component\Filesystem\Filesystem;
 
-class PushLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class PushLoader implements DataLoaderInterface
 {
-    /**
-     * @var string
-     */
-    protected $apiKey;
+    private string $apiKey;
 
-    /**
-     * @var bool
-     */
-    protected $ignoreNotEmptyQueue = false;
+    private bool $ignoreNotEmptyQueue = false;
 
-    /**
-     * @var string
-     */
-    protected $importFilePath;
+    private string $importFilePath;
 
     public function __construct(
-        protected Filesystem $filesystem
+        private readonly Filesystem $filesystem,
     ) {
     }
 

--- a/src/DataSource/Loader/SftpLoader.php
+++ b/src/DataSource/Loader/SftpLoader.php
@@ -21,40 +21,25 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Logger;
 use Symfony\Component;
 
-class SftpLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class SftpLoader implements DataLoaderInterface
 {
-    /**
-     * @var string
-     */
-    protected $importFilePath;
+    private string $importFilePath;
 
-    /**
-     * @var string
-     */
-    protected $remotePath;
+    private string $remotePath;
 
-    /**
-     * @var string
-     */
-    protected $host;
+    private string $host;
 
-    /**
-     * @var string
-     */
-    protected $port;
+    private string $port;
 
-    /**
-     * @var string
-     */
-    protected $username;
+    private string $username;
 
-    /**
-     * @var string
-     */
-    protected $password;
+    private string $password;
 
     public function __construct(
-        protected Component\Filesystem\Filesystem $filesystem
+        private readonly Component\Filesystem\Filesystem $filesystem,
     ) {
     }
 

--- a/src/DataSource/Loader/SqlLoader.php
+++ b/src/DataSource/Loader/SqlLoader.php
@@ -23,7 +23,10 @@ use Pimcore;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Symfony\Component;
 
-class SqlLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class SqlLoader implements DataLoaderInterface
 {
     private string $connection;
 
@@ -39,7 +42,7 @@ class SqlLoader implements DataLoaderInterface
 
     private Connection $databaseConnection;
 
-    public function __construct(private Component\Filesystem\Filesystem $filesystem)
+    public function __construct(private readonly Component\Filesystem\Filesystem $filesystem)
     {
     }
 

--- a/src/DataSource/Loader/UploadLoader.php
+++ b/src/DataSource/Loader/UploadLoader.php
@@ -16,25 +16,20 @@ use League\Flysystem\FilesystemOperator;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Helper\TemporaryFileHelperTrait;
 
-class UploadLoader implements DataLoaderInterface
+/**
+ * @internal
+ */
+final class UploadLoader implements DataLoaderInterface
 {
     use TemporaryFileHelperTrait;
 
-    /**
-     * @var string
-     */
-    protected $uploadFilePath;
+    private string $uploadFilePath;
 
-    /**
-     * @var string
-     */
-    protected $temporaryFile = null;
+    private ?string $temporaryFile = null;
 
-    protected FilesystemOperator $pimcoreDataImporterUploadStorage;
-
-    public function __construct(FilesystemOperator $pimcoreDataImporterUploadStorage)
-    {
-        $this->pimcoreDataImporterUploadStorage = $pimcoreDataImporterUploadStorage;
+    public function __construct(
+        private readonly FilesystemOperator $pimcoreDataImporterUploadStorage,
+    ) {
     }
 
     public function loadData(): string

--- a/src/DependencyInjection/CompilerPass/CleanupStrategyConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/CleanupStrategyConfigurationFactoryPass.php
@@ -17,9 +17,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class CleanupStrategyConfigurationFactoryPass implements CompilerPassInterface
+/**
+ * @internal
+ */
+final class CleanupStrategyConfigurationFactoryPass implements CompilerPassInterface
 {
-    const cleanup_tag = 'pimcore.datahub.data_importer.cleanup';
+    private const cleanup_tag = 'pimcore.datahub.data_importer.cleanup';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/CompilerPass/CleanupStrategyConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/CleanupStrategyConfigurationFactoryPass.php
@@ -22,11 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class CleanupStrategyConfigurationFactoryPass implements CompilerPassInterface
 {
-    private const cleanup_tag = 'pimcore.datahub.data_importer.cleanup';
+    private const CLEANUP_TAG = 'pimcore.datahub.data_importer.cleanup';
 
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds(self::cleanup_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::CLEANUP_TAG);
         $cleanupStrategies = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/CompilerPass/InterpreterConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/InterpreterConfigurationFactoryPass.php
@@ -22,11 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class InterpreterConfigurationFactoryPass implements CompilerPassInterface
 {
-    private const interpreter_tag = 'pimcore.datahub.data_importer.interpreter';
+    private const INTERPRETER_TAG = 'pimcore.datahub.data_importer.interpreter';
 
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds(self::interpreter_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::INTERPRETER_TAG);
         $interpreters = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/CompilerPass/InterpreterConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/InterpreterConfigurationFactoryPass.php
@@ -17,9 +17,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class InterpreterConfigurationFactoryPass implements CompilerPassInterface
+/**
+ * @internal
+ */
+final class InterpreterConfigurationFactoryPass implements CompilerPassInterface
 {
-    const interpreter_tag = 'pimcore.datahub.data_importer.interpreter';
+    private const interpreter_tag = 'pimcore.datahub.data_importer.interpreter';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/CompilerPass/LoaderConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/LoaderConfigurationFactoryPass.php
@@ -22,11 +22,11 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class LoaderConfigurationFactoryPass implements CompilerPassInterface
 {
-    private const loader_tag = 'pimcore.datahub.data_importer.loader';
+    private const LOADER_TAG = 'pimcore.datahub.data_importer.loader';
 
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds(self::loader_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::LOADER_TAG);
         $loader = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/CompilerPass/LoaderConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/LoaderConfigurationFactoryPass.php
@@ -17,9 +17,12 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class LoaderConfigurationFactoryPass implements CompilerPassInterface
+/**
+ * @internal
+ */
+final class LoaderConfigurationFactoryPass implements CompilerPassInterface
 {
-    const loader_tag = 'pimcore.datahub.data_importer.loader';
+    private const loader_tag = 'pimcore.datahub.data_importer.loader';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/CompilerPass/MappingConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/MappingConfigurationFactoryPass.php
@@ -22,13 +22,13 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class MappingConfigurationFactoryPass implements CompilerPassInterface
 {
-    private const operator_tag = 'pimcore.datahub.data_importer.operator';
+    private const OPERATOR_TAG = 'pimcore.datahub.data_importer.operator';
 
-    private const data_target_tag = 'pimcore.datahub.data_importer.data_target';
+    private const DATA_TARGET_TAG = 'pimcore.datahub.data_importer.data_target';
 
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds(self::operator_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::OPERATOR_TAG);
         $operators = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {
@@ -38,7 +38,7 @@ final class MappingConfigurationFactoryPass implements CompilerPassInterface
             }
         }
 
-        $taggedServices = $container->findTaggedServiceIds(self::data_target_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::DATA_TARGET_TAG);
         $dataTargets = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/CompilerPass/MappingConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/MappingConfigurationFactoryPass.php
@@ -17,11 +17,14 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class MappingConfigurationFactoryPass implements CompilerPassInterface
+/**
+ * @internal
+ */
+final class MappingConfigurationFactoryPass implements CompilerPassInterface
 {
-    const operator_tag = 'pimcore.datahub.data_importer.operator';
+    private const operator_tag = 'pimcore.datahub.data_importer.operator';
 
-    const data_target_tag = 'pimcore.datahub.data_importer.data_target';
+    private const data_target_tag = 'pimcore.datahub.data_importer.data_target';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/CompilerPass/ResolverConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/ResolverConfigurationFactoryPass.php
@@ -17,15 +17,18 @@ use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
-class ResolverConfigurationFactoryPass implements CompilerPassInterface
+/**
+ * @internal
+ */
+final class ResolverConfigurationFactoryPass implements CompilerPassInterface
 {
-    const load_tag = 'pimcore.datahub.data_importer.resolver.load';
+    private const load_tag = 'pimcore.datahub.data_importer.resolver.load';
 
-    const location_tag = 'pimcore.datahub.data_importer.resolver.location';
+    private const location_tag = 'pimcore.datahub.data_importer.resolver.location';
 
-    const publish_tag = 'pimcore.datahub.data_importer.resolver.publish';
+    private const publish_tag = 'pimcore.datahub.data_importer.resolver.publish';
 
-    const factory_tag = 'pimcore.datahub.data_importer.resolver.factory';
+    private const factory_tag = 'pimcore.datahub.data_importer.resolver.factory';
 
     public function process(ContainerBuilder $container): void
     {

--- a/src/DependencyInjection/CompilerPass/ResolverConfigurationFactoryPass.php
+++ b/src/DependencyInjection/CompilerPass/ResolverConfigurationFactoryPass.php
@@ -22,17 +22,17 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 final class ResolverConfigurationFactoryPass implements CompilerPassInterface
 {
-    private const load_tag = 'pimcore.datahub.data_importer.resolver.load';
+    private const LOAD_TAG = 'pimcore.datahub.data_importer.resolver.load';
 
-    private const location_tag = 'pimcore.datahub.data_importer.resolver.location';
+    private const LOCATION_TAG = 'pimcore.datahub.data_importer.resolver.location';
 
-    private const publish_tag = 'pimcore.datahub.data_importer.resolver.publish';
+    private const PUBLISH_TAG = 'pimcore.datahub.data_importer.resolver.publish';
 
-    private const factory_tag = 'pimcore.datahub.data_importer.resolver.factory';
+    private const FACTORY_TAG = 'pimcore.datahub.data_importer.resolver.factory';
 
     public function process(ContainerBuilder $container): void
     {
-        $taggedServices = $container->findTaggedServiceIds(self::load_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::LOAD_TAG);
         $loadStrategies = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {
@@ -42,7 +42,7 @@ final class ResolverConfigurationFactoryPass implements CompilerPassInterface
             }
         }
 
-        $taggedServices = $container->findTaggedServiceIds(self::location_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::LOCATION_TAG);
         $locationStrategies = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {
@@ -52,7 +52,7 @@ final class ResolverConfigurationFactoryPass implements CompilerPassInterface
             }
         }
 
-        $taggedServices = $container->findTaggedServiceIds(self::publish_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::PUBLISH_TAG);
         $publishStrategies = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {
@@ -62,7 +62,7 @@ final class ResolverConfigurationFactoryPass implements CompilerPassInterface
             }
         }
 
-        $taggedServices = $container->findTaggedServiceIds(self::factory_tag);
+        $taggedServices = $container->findTaggedServiceIds(self::FACTORY_TAG);
         $factories = [];
         if (sizeof($taggedServices)) {
             foreach ($taggedServices as $id => $tags) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -19,8 +19,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
  * This is the class that validates and merges configuration from your app/config files.
  *
  * To learn more see {@link http://symfony.com/doc/current/cookbook/bundles/configuration.html}
+ *
+ * @internal
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * {@inheritdoc}

--- a/src/DependencyInjection/PimcoreDataImporterExtension.php
+++ b/src/DependencyInjection/PimcoreDataImporterExtension.php
@@ -26,8 +26,10 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
  * This is the class that loads and manages your bundle configuration.
  *
  * @link http://symfony.com/doc/current/cookbook/bundles/extension.html
+ *
+ * @internal
  */
-class PimcoreDataImporterExtension extends Extension implements PrependExtensionInterface
+final class PimcoreDataImporterExtension extends Extension implements PrependExtensionInterface
 {
     /**
      * {@inheritdoc}

--- a/src/Event/DataObject/AbstractDataObjectImportEvent.php
+++ b/src/Event/DataObject/AbstractDataObjectImportEvent.php
@@ -17,28 +17,12 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class AbstractDataObjectImportEvent extends Event
 {
-    /**
-     * @var string
-     */
-    protected $configName;
+    protected string $configName;
 
-    /**
-     * @var array
-     */
-    protected $rawData;
+    protected array $rawData;
 
-    /**
-     * @var ElementInterface
-     */
-    protected $dataObject;
+    protected ElementInterface $dataObject;
 
-    /**
-     * AbstractDataObjectImportEvent constructor.
-     *
-     * @param string $configName
-     * @param array $rawData
-     * @param ElementInterface $dataObject
-     */
     public function __construct(string $configName, array $rawData, ElementInterface $dataObject)
     {
         $this->configName = $configName;

--- a/src/Event/DataObject/PostSaveEvent.php
+++ b/src/Event/DataObject/PostSaveEvent.php
@@ -15,6 +15,6 @@ namespace Pimcore\Bundle\DataImporterBundle\Event\DataObject;
 /**
  * Fired just after an imported data object is saved
  */
-class PostSaveEvent extends AbstractDataObjectImportEvent
+final class PostSaveEvent extends AbstractDataObjectImportEvent
 {
 }

--- a/src/Event/DataObject/PreSaveEvent.php
+++ b/src/Event/DataObject/PreSaveEvent.php
@@ -15,6 +15,6 @@ namespace Pimcore\Bundle\DataImporterBundle\Event\DataObject;
 /**
  * Fired just before an imported data object will be saved
  */
-class PreSaveEvent extends AbstractDataObjectImportEvent
+final class PreSaveEvent extends AbstractDataObjectImportEvent
 {
 }

--- a/src/Event/DataObject/ProcessElementExceptionEvent.php
+++ b/src/Event/DataObject/ProcessElementExceptionEvent.php
@@ -16,15 +16,15 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\MappingConfiguration;
 use Pimcore\Model\Element\ElementInterface;
 use Throwable;
 
-class ProcessElementExceptionEvent extends AbstractDataObjectImportEvent
+final class ProcessElementExceptionEvent extends AbstractDataObjectImportEvent
 {
     public function __construct(
         string $configName,
         array $rawData,
         ElementInterface $dataObject,
-        private ?string $message,
-        private Throwable $exception,
-        private ?MappingConfiguration $mappingConfiguration
+        private readonly ?string $message,
+        private readonly Throwable $exception,
+        private readonly ?MappingConfiguration $mappingConfiguration,
     ) {
         parent::__construct($configName, $rawData, $dataObject);
     }

--- a/src/Event/PostPreparationEvent.php
+++ b/src/Event/PostPreparationEvent.php
@@ -12,19 +12,13 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Event;
 
-class PostPreparationEvent
+final readonly class PostPreparationEvent
 {
-    protected string $configName;
-
-    protected string $executionType;
-
-    protected bool $fileInterpreted;
-
-    public function __construct(string $configName, string $executionType, bool $fileInterpreted)
-    {
-        $this->configName = $configName;
-        $this->executionType = $executionType;
-        $this->fileInterpreted = $fileInterpreted;
+    public function __construct(
+        private string $configName,
+        private string $executionType,
+        private bool $fileInterpreted,
+    ) {
     }
 
     public function getConfigName(): string

--- a/src/EventListener/ConfigurationEventSubscriber.php
+++ b/src/EventListener/ConfigurationEventSubscriber.php
@@ -23,34 +23,18 @@ use Pimcore\Logger;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface as EventSubscriberInterfaceAlias;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-class ConfigurationEventSubscriber implements EventSubscriberInterfaceAlias
+/**
+ * @internal
+ */
+final class ConfigurationEventSubscriber implements EventSubscriberInterfaceAlias
 {
-    /**
-     * @var DeltaChecker
-     */
-    protected $deltaChecker;
-
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
-
-    /**
-     * @var ExecutionService
-     */
-    protected $executionService;
-
-    protected FilesystemOperator $pimcoreDataImporterUploadStorage;
-
-    protected FilesystemOperator $pimcoreDataImporterPreviewStorage;
-
-    public function __construct(DeltaChecker $deltaChecker, QueueService $queueService, ExecutionService $executionService, FilesystemOperator $pimcoreDataImporterUploadStorage, FilesystemOperator $pimcoreDataImporterPreviewStorage)
-    {
-        $this->deltaChecker = $deltaChecker;
-        $this->queueService = $queueService;
-        $this->executionService = $executionService;
-        $this->pimcoreDataImporterUploadStorage = $pimcoreDataImporterUploadStorage;
-        $this->pimcoreDataImporterPreviewStorage = $pimcoreDataImporterPreviewStorage;
+    public function __construct(
+        private readonly DeltaChecker $deltaChecker,
+        private readonly QueueService $queueService,
+        private readonly ExecutionService $executionService,
+        private readonly FilesystemOperator $pimcoreDataImporterUploadStorage,
+        private readonly FilesystemOperator $pimcoreDataImporterPreviewStorage,
+    ) {
     }
 
     /**

--- a/src/EventListener/DataImporterListener.php
+++ b/src/EventListener/DataImporterListener.php
@@ -15,11 +15,14 @@ namespace Pimcore\Bundle\DataImporterBundle\EventListener;
 use Pimcore\Bundle\DataImporterBundle\Event\PostPreparationEvent;
 use Pimcore\Bundle\DataImporterBundle\Messenger\DataImporterHandler;
 
-class DataImporterListener
+/**
+ * @internal
+ */
+final readonly class DataImporterListener
 {
     public function __construct(
-        protected DataImporterHandler $dataImporterHandler,
-        protected bool $messengerQueueActivated
+        private DataImporterHandler $dataImporterHandler,
+        private bool $messengerQueueActivated,
     ) {
     }
 

--- a/src/Exception/ElementNotFoundException.php
+++ b/src/Exception/ElementNotFoundException.php
@@ -12,6 +12,6 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Exception;
 
-class ElementNotFoundException extends \Exception
+final class ElementNotFoundException extends \Exception
 {
 }

--- a/src/Exception/InvalidConfigurationException.php
+++ b/src/Exception/InvalidConfigurationException.php
@@ -12,6 +12,6 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Exception;
 
-class InvalidConfigurationException extends \Exception
+final class InvalidConfigurationException extends \Exception
 {
 }

--- a/src/Exception/InvalidInputException.php
+++ b/src/Exception/InvalidInputException.php
@@ -12,6 +12,6 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Exception;
 
-class InvalidInputException extends \Exception
+final class InvalidInputException extends \Exception
 {
 }

--- a/src/Exception/QueueNotEmptyException.php
+++ b/src/Exception/QueueNotEmptyException.php
@@ -12,6 +12,6 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Exception;
 
-class QueueNotEmptyException extends \Exception
+final class QueueNotEmptyException extends \Exception
 {
 }

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -16,9 +16,12 @@ use Pimcore\Bundle\DataImporterBundle\Migrations\Version20240715160305;
 use Pimcore\Extension\Bundle\Installer\SettingsStoreAwareInstaller;
 use Pimcore\Model\User\Permission;
 
-class Installer extends SettingsStoreAwareInstaller
+/**
+ * @internal
+ */
+final class Installer extends SettingsStoreAwareInstaller
 {
-    const DATAHUB_ADAPTER_PERMISSION = 'plugin_datahub_adapter_dataImporterDataObject';
+    public const DATAHUB_ADAPTER_PERMISSION = 'plugin_datahub_adapter_dataImporterDataObject';
 
     /**
      * {@inheritdoc}

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -44,7 +44,7 @@ final class Installer extends SettingsStoreAwareInstaller
         parent::install();
     }
 
-    public function getLastMigrationVersionClassName(): ?string
+    public function getLastMigrationVersionClassName(): string
     {
         return Version20240715160305::class;
     }

--- a/src/Maintenance/RestartQueueWorkersTask.php
+++ b/src/Maintenance/RestartQueueWorkersTask.php
@@ -16,11 +16,14 @@ use Pimcore\Bundle\DataImporterBundle\Messenger\DataImporterHandler;
 use Pimcore\Bundle\DataImporterBundle\Processing\ImportProcessingService;
 use Pimcore\Maintenance\TaskInterface;
 
-class RestartQueueWorkersTask implements TaskInterface
+/**
+ * @internal
+ */
+final readonly class RestartQueueWorkersTask implements TaskInterface
 {
     public function __construct(
-        protected DataImporterHandler $dataImporterHandler,
-        protected bool $messengerQueueActivated
+        private DataImporterHandler $dataImporterHandler,
+        private bool $messengerQueueActivated,
     ) {
     }
 

--- a/src/Mapping/DataTarget/Classificationstore.php
+++ b/src/Mapping/DataTarget/Classificationstore.php
@@ -15,27 +15,18 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Element\ElementInterface;
 
-class Classificationstore implements DataTargetInterface
+/**
+ * @internal
+ */
+final class Classificationstore implements DataTargetInterface
 {
-    /**
-     * @var string
-     */
-    protected $fieldName;
+    private string $fieldName;
 
-    /**
-     * @var string
-     */
-    protected $language;
+    private string $language;
 
-    /**
-     * @var int
-     */
-    protected $keyId;
+    private int $keyId;
 
-    /**
-     * @var int
-     */
-    protected $groupId;
+    private int $groupId;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/DataTarget/ClassificationstoreBatch.php
+++ b/src/Mapping/DataTarget/ClassificationstoreBatch.php
@@ -16,17 +16,14 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidInputException;
 use Pimcore\Model\Element\ElementInterface;
 
-class ClassificationstoreBatch implements DataTargetInterface
+/**
+ * @internal
+ */
+final class ClassificationstoreBatch implements DataTargetInterface
 {
-    /**
-     * @var string
-     */
-    protected $fieldName;
+    private string $fieldName;
 
-    /**
-     * @var string
-     */
-    protected $language;
+    private string $language;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -18,6 +18,9 @@ use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
 use Pimcore\Model\Element\ElementInterface;
 
+/**
+ * @internal
+ */
 class Direct implements DataTargetInterface
 {
     /**

--- a/src/Mapping/DataTarget/ManyToManyRelation.php
+++ b/src/Mapping/DataTarget/ManyToManyRelation.php
@@ -18,16 +18,16 @@ use Pimcore\Model\DataObject\Data\ElementMetadata;
 use Pimcore\Model\DataObject\Data\ObjectMetadata;
 use Pimcore\Model\Element\Service;
 
-class ManyToManyRelation extends Direct
+/**
+ * @internal
+ */
+final class ManyToManyRelation extends Direct
 {
-    const OVERWRITE_MODE_MERGE = 'merge';
+    private const OVERWRITE_MODE_MERGE = 'merge';
 
-    const OVERWRITE_MODE_REPLACE = 'replace';
+    private const OVERWRITE_MODE_REPLACE = 'replace';
 
-    /**
-     * @var bool
-     */
-    protected $overwriteMode;
+    private string $overwriteMode;
 
     /**
      * @param array $settings
@@ -84,7 +84,7 @@ class ManyToManyRelation extends Direct
      *
      * @throws \Exception
      */
-    protected function getMergedDataArray($valueContainer, string $getter, string $fieldType, $data): array
+    private function getMergedDataArray($valueContainer, string $getter, string $fieldType, $data): array
     {
         if (null === $data) {
             return [];

--- a/src/Mapping/MappingConfiguration.php
+++ b/src/Mapping/MappingConfiguration.php
@@ -15,27 +15,18 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping;
 use Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget\DataTargetInterface;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\OperatorInterface;
 
-class MappingConfiguration
+/**
+ * @internal
+ */
+final class MappingConfiguration
 {
-    /**
-     * @var string
-     */
-    protected $label;
+    private string $label;
 
-    /**
-     * @var mixed
-     */
-    protected $dataSourceIndex;
+    private mixed $dataSourceIndex;
 
-    /**
-     * @var array
-     */
-    protected $transformationPipeline;
+    private array $transformationPipeline;
 
-    /**
-     * @var DataTargetInterface
-     */
-    protected $dataTarget;
+    private DataTargetInterface $dataTarget;
 
     public function getLabel(): string
     {

--- a/src/Mapping/MappingConfigurationFactory.php
+++ b/src/Mapping/MappingConfigurationFactory.php
@@ -16,33 +16,21 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget\DataTargetInterface;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\OperatorInterface;
 
-class MappingConfigurationFactory
+/**
+ * @internal
+ */
+final class MappingConfigurationFactory
 {
-    /**
-     * @var MappingConfiguration
-     */
-    protected $mappingConfigurationBluePrint;
-
-    /**
-     * @var OperatorInterface[]
-     */
-    protected $operatorBluePrints;
-
-    /**
-     * @var DataTargetInterface[]
-     */
-    protected $dataTargetBluePrints;
-
     /**
      * @param MappingConfiguration $mappingConfigurationBluePrint
      * @param OperatorInterface[] $operatorBluePrints
      * @param DataTargetInterface[] $dataTargetBluePrints
      */
-    public function __construct(MappingConfiguration $mappingConfigurationBluePrint, array $operatorBluePrints, array $dataTargetBluePrints)
-    {
-        $this->mappingConfigurationBluePrint = $mappingConfigurationBluePrint;
-        $this->operatorBluePrints = $operatorBluePrints;
-        $this->dataTargetBluePrints = $dataTargetBluePrints;
+    public function __construct(
+        private readonly MappingConfiguration $mappingConfigurationBluePrint,
+        private readonly array $operatorBluePrints,
+        private readonly array $dataTargetBluePrints,
+    ) {
     }
 
     /**
@@ -53,7 +41,7 @@ class MappingConfigurationFactory
      *
      * @throws InvalidConfigurationException
      */
-    protected function buildTransformationPipeline(string $configName, array $configArray): array
+    private function buildTransformationPipeline(string $configName, array $configArray): array
     {
         $transformationPipeline = [];
 
@@ -79,7 +67,7 @@ class MappingConfigurationFactory
      *
      * @throws InvalidConfigurationException
      */
-    protected function buildDataTarget(array $config): DataTargetInterface
+    private function buildDataTarget(array $config): DataTargetInterface
     {
         if (empty($config['type']) || !array_key_exists($config['type'], $this->dataTargetBluePrints)) {
             throw new InvalidConfigurationException('Unknown data target type `' . ($config['type'] ?? '') . '`');

--- a/src/Mapping/Operator/AbstractOperator.php
+++ b/src/Mapping/Operator/AbstractOperator.php
@@ -14,6 +14,9 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Operator;
 
 use Pimcore\Bundle\ApplicationLoggerBundle\ApplicationLogger;
 
+/**
+ * @internal
+ */
 abstract class AbstractOperator implements OperatorInterface
 {
     /**

--- a/src/Mapping/Operator/Factory/AsArray.php
+++ b/src/Mapping/Operator/Factory/AsArray.php
@@ -15,7 +15,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Operator\Factory;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class AsArray extends AbstractOperator
+/**
+ * @internal
+ */
+final class AsArray extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/AsColor.php
+++ b/src/Mapping/Operator/Factory/AsColor.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Model\DataObject\Data\RgbaColor;
 
-class AsColor extends AbstractOperator
+/**
+ * @internal
+ */
+final class AsColor extends AbstractOperator
 {
     /**
      * @throws \Exception

--- a/src/Mapping/Operator/Factory/AsCountries.php
+++ b/src/Mapping/Operator/Factory/AsCountries.php
@@ -23,8 +23,10 @@ use Pimcore\Localization\LocaleServiceInterface;
  */
 final class AsCountries extends AbstractOperator
 {
-    public function __construct(ApplicationLogger $applicationLogger, private readonly LocaleServiceInterface $localeService)
-    {
+    public function __construct(
+        ApplicationLogger $applicationLogger,
+        private readonly LocaleServiceInterface $localeService,
+    ) {
         parent::__construct($applicationLogger);
     }
 

--- a/src/Mapping/Operator/Factory/AsCountries.php
+++ b/src/Mapping/Operator/Factory/AsCountries.php
@@ -18,9 +18,12 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Localization\LocaleServiceInterface;
 
-class AsCountries extends AbstractOperator
+/**
+ * @internal
+ */
+final class AsCountries extends AbstractOperator
 {
-    public function __construct(ApplicationLogger $applicationLogger, private LocaleServiceInterface $localeService)
+    public function __construct(ApplicationLogger $applicationLogger, private readonly LocaleServiceInterface $localeService)
     {
         parent::__construct($applicationLogger);
     }

--- a/src/Mapping/Operator/Factory/AsGeobounds.php
+++ b/src/Mapping/Operator/Factory/AsGeobounds.php
@@ -18,7 +18,10 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService
 use Pimcore\Model\DataObject\Data\Geobounds;
 use Pimcore\Model\DataObject\Data\GeoCoordinates;
 
-class AsGeobounds extends AbstractOperator
+/**
+ * @internal
+ */
+final class AsGeobounds extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/AsGeopoint.php
+++ b/src/Mapping/Operator/Factory/AsGeopoint.php
@@ -17,7 +17,10 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Model\DataObject\Data\GeoCoordinates;
 
-class AsGeopoint extends AbstractOperator
+/**
+ * @internal
+ */
+final class AsGeopoint extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/AsGeopolygon.php
+++ b/src/Mapping/Operator/Factory/AsGeopolygon.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\GeopolyAbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class AsGeopolygon extends GeopolyAbstractOperator
+/**
+ * @internal
+ */
+final class AsGeopolygon extends GeopolyAbstractOperator
 {
     /**
      * @param string $inputType

--- a/src/Mapping/Operator/Factory/AsGeopolyline.php
+++ b/src/Mapping/Operator/Factory/AsGeopolyline.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\GeopolyAbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class AsGeopolyline extends GeopolyAbstractOperator
+/**
+ * @internal
+ */
+final class AsGeopolyline extends GeopolyAbstractOperator
 {
     /**
      * @param string $inputType

--- a/src/Mapping/Operator/Factory/Boolean.php
+++ b/src/Mapping/Operator/Factory/Boolean.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Boolean extends AbstractOperator
+/**
+ * @internal
+ */
+final class Boolean extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/Date.php
+++ b/src/Mapping/Operator/Factory/Date.php
@@ -16,12 +16,12 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Date extends AbstractOperator
+/**
+ * @internal
+ */
+final class Date extends AbstractOperator
 {
-    /**
-     * @var string
-     */
-    protected $format;
+    private string $format;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Factory/Gallery.php
+++ b/src/Mapping/Operator/Factory/Gallery.php
@@ -19,7 +19,10 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Data\Hotspotimage;
 use Pimcore\Model\DataObject\Data\ImageGallery;
 
-class Gallery extends AbstractOperator
+/**
+ * @internal
+ */
+final class Gallery extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/ImageAdvanced.php
+++ b/src/Mapping/Operator/Factory/ImageAdvanced.php
@@ -18,7 +18,10 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService
 use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject\Data\Hotspotimage;
 
-class ImageAdvanced extends AbstractOperator
+/**
+ * @internal
+ */
+final class ImageAdvanced extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/InputQuantityValue.php
+++ b/src/Mapping/Operator/Factory/InputQuantityValue.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
 
-class InputQuantityValue extends QuantityValue
+/**
+ * @internal
+ */
+final class InputQuantityValue extends QuantityValue
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/InputQuantityValueArray.php
+++ b/src/Mapping/Operator/Factory/InputQuantityValueArray.php
@@ -15,7 +15,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Operator\Factory;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class InputQuantityValueArray extends QuantityValueArray
+/**
+ * @internal
+ */
+final class InputQuantityValueArray extends QuantityValueArray
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Factory/Numeric.php
+++ b/src/Mapping/Operator/Factory/Numeric.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Numeric extends AbstractOperator
+/**
+ * @internal
+ */
+final class Numeric extends AbstractOperator
 {
     private bool $returnNullIfEmpty = false;
 

--- a/src/Mapping/Operator/Factory/QuantityValue.php
+++ b/src/Mapping/Operator/Factory/QuantityValue.php
@@ -17,6 +17,9 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 use Pimcore\Model\DataObject\QuantityValue\Unit;
 
+/**
+ * @internal
+ */
 class QuantityValue extends AbstractOperator
 {
     /**

--- a/src/Mapping/Operator/Factory/QuantityValueArray.php
+++ b/src/Mapping/Operator/Factory/QuantityValueArray.php
@@ -16,6 +16,9 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
+/**
+ * @internal
+ */
 class QuantityValueArray extends AbstractOperator
 {
     /**

--- a/src/Mapping/Operator/GeopolyAbstractOperator.php
+++ b/src/Mapping/Operator/GeopolyAbstractOperator.php
@@ -14,6 +14,9 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Operator;
 
 use Pimcore\Model\DataObject\Data\GeoCoordinates;
 
+/**
+ * @internal
+ */
 abstract class GeopolyAbstractOperator extends AbstractOperator
 {
     /**

--- a/src/Mapping/Operator/Simple/Combine.php
+++ b/src/Mapping/Operator/Simple/Combine.php
@@ -16,12 +16,12 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Combine extends AbstractOperator
+/**
+ * @internal
+ */
+final class Combine extends AbstractOperator
 {
-    /**
-     * @var string
-     */
-    protected $glue;
+    private string $glue;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/ConditionalConversion.php
+++ b/src/Mapping/Operator/Simple/ConditionalConversion.php
@@ -16,17 +16,14 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class ConditionalConversion extends AbstractOperator
+/**
+ * @internal
+ */
+final class ConditionalConversion extends AbstractOperator
 {
-    /**
-     * @var string
-     */
-    protected $original;
+    private string $original;
 
-    /**
-     * @var string
-     */
-    protected $converted;
+    private string $converted;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/Explode.php
+++ b/src/Mapping/Operator/Simple/Explode.php
@@ -16,17 +16,14 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Explode extends AbstractOperator
+/**
+ * @internal
+ */
+final class Explode extends AbstractOperator
 {
-    /**
-     * @var string
-     */
-    protected $delimiter;
+    private string $delimiter;
 
-    /**
-     * @var bool
-     */
-    protected $keepSubArrays;
+    private bool $keepSubArrays;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/FlattenArray.php
+++ b/src/Mapping/Operator/Simple/FlattenArray.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class FlattenArray extends AbstractOperator
+/**
+ * @internal
+ */
+final class FlattenArray extends AbstractOperator
 {
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/HtmlDecode.php
+++ b/src/Mapping/Operator/Simple/HtmlDecode.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class HtmlDecode extends AbstractOperator
+/**
+ * @internal
+ */
+final class HtmlDecode extends AbstractOperator
 {
     /**
      * @param mixed $inputData

--- a/src/Mapping/Operator/Simple/ImportAsset.php
+++ b/src/Mapping/Operator/Simple/ImportAsset.php
@@ -20,6 +20,9 @@ use Pimcore\Model\Asset;
 use Pimcore\Model\Element\DuplicateFullPathException;
 use Pimcore\Model\Element\Service;
 
+/**
+ * @internal
+ */
 class ImportAsset extends AbstractOperator
 {
     /**

--- a/src/Mapping/Operator/Simple/LoadAsset.php
+++ b/src/Mapping/Operator/Simple/LoadAsset.php
@@ -16,16 +16,16 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\PimcoreDataImporterBundle;
 use Pimcore\Model\Asset;
 
-class LoadAsset extends ImportAsset
+/**
+ * @internal
+ */
+final class LoadAsset extends ImportAsset
 {
-    const LOAD_STRATEGY_ID = 'id';
+    private const LOAD_STRATEGY_ID = 'id';
 
-    const LOAD_STRATEGY_PATH = 'path';
+    private const LOAD_STRATEGY_PATH = 'path';
 
-    /**
-     * @var string
-     */
-    protected $loadStrategy;
+    private string $loadStrategy;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/LoadDataObject.php
+++ b/src/Mapping/Operator/Simple/LoadDataObject.php
@@ -21,45 +21,30 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Symfony\Contracts\Service\Attribute\Required;
 
-class LoadDataObject extends AbstractOperator
+/**
+ * @internal
+ */
+final class LoadDataObject extends AbstractOperator
 {
-    const LOAD_STRATEGY_ID = 'id';
+    private const LOAD_STRATEGY_ID = 'id';
 
-    const LOAD_STRATEGY_PATH = 'path';
+    private const LOAD_STRATEGY_PATH = 'path';
 
-    const LOAD_STRATEGY_ATTRIBUTE = 'attribute';
+    private const LOAD_STRATEGY_ATTRIBUTE = 'attribute';
 
-    /**
-     * @var string
-     */
-    protected $loadStrategy;
+    private string $loadStrategy;
 
-    /**
-     * @var string
-     */
-    protected $attributeLanguage;
+    private string $attributeLanguage;
 
-    /**
-     * @var string
-     */
-    protected $attributeName;
+    private string $attributeName;
 
-    /**
-     * @var string
-     */
-    protected $attributeDataObjectClassId;
+    private string $attributeDataObjectClassId;
 
-    /**
-     * @var bool
-     */
-    protected $partialMatch;
+    private bool $partialMatch;
 
-    /**
-     * @var bool
-     */
-    protected $loadUnpublished;
+    private bool $loadUnpublished;
 
-    protected DataObjectLoader $dataObjectLoader;
+    private DataObjectLoader $dataObjectLoader;
 
     /**
      * @param DataObjectLoader $dataObjectLoader

--- a/src/Mapping/Operator/Simple/ObjectField.php
+++ b/src/Mapping/Operator/Simple/ObjectField.php
@@ -18,7 +18,10 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService
 use Pimcore\Bundle\DataImporterBundle\PimcoreDataImporterBundle;
 use Pimcore\Model\Element\ElementInterface;
 
-class ObjectField extends AbstractOperator
+/**
+ * @internal
+ */
+final class ObjectField extends AbstractOperator
 {
     private string $attribute;
 

--- a/src/Mapping/Operator/Simple/ReduceArrayKeyValuePairs.php
+++ b/src/Mapping/Operator/Simple/ReduceArrayKeyValuePairs.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class ReduceArrayKeyValuePairs extends AbstractOperator
+/**
+ * @internal
+ */
+final class ReduceArrayKeyValuePairs extends AbstractOperator
 {
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/StaticText.php
+++ b/src/Mapping/Operator/Simple/StaticText.php
@@ -21,9 +21,9 @@ use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService
  */
 final class StaticText extends AbstractOperator
 {
-    private const MODE_APPEND = 'append';
+    public const MODE_APPEND = 'append';
 
-    private const MODE_PREPEND = 'prepend';
+    public const MODE_PREPEND = 'prepend';
 
     private string $mode;
 

--- a/src/Mapping/Operator/Simple/StaticText.php
+++ b/src/Mapping/Operator/Simple/StaticText.php
@@ -16,26 +16,20 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class StaticText extends AbstractOperator
+/**
+ * @internal
+ */
+final class StaticText extends AbstractOperator
 {
-    const MODE_APPEND = 'append';
+    private const MODE_APPEND = 'append';
 
-    const MODE_PREPEND = 'prepend';
+    private const MODE_PREPEND = 'prepend';
 
-    /**
-     * @var string
-     */
-    protected $mode;
+    private string $mode;
 
-    /**
-     * @var string
-     */
-    protected $text;
+    private string $text;
 
-    /**
-     * @var bool
-     */
-    protected $alwaysAdd;
+    private bool $alwaysAdd;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/StringReplace.php
+++ b/src/Mapping/Operator/Simple/StringReplace.php
@@ -16,11 +16,14 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class StringReplace extends AbstractOperator
+/**
+ * @internal
+ */
+final class StringReplace extends AbstractOperator
 {
-    protected string $search;
+    private string $search;
 
-    protected string $replace;
+    private string $replace;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Operator/Simple/Trim.php
+++ b/src/Mapping/Operator/Simple/Trim.php
@@ -16,18 +16,18 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Operator\AbstractOperator;
 use Pimcore\Bundle\DataImporterBundle\Mapping\Type\TransformationDataTypeService;
 
-class Trim extends AbstractOperator
+/**
+ * @internal
+ */
+final class Trim extends AbstractOperator
 {
-    const MODE_BOTH = 'both';
+    private const MODE_BOTH = 'both';
 
-    const MODE_LEFT = 'left';
+    private const MODE_LEFT = 'left';
 
-    const MODE_RIGHT = 'right';
+    private const MODE_RIGHT = 'right';
 
-    /**
-     * @var string
-     */
-    protected $mode;
+    private string $mode;
 
     public function setSettings(array $settings): void
     {

--- a/src/Mapping/Type/ClassificationStoreDataTypeService.php
+++ b/src/Mapping/Type/ClassificationStoreDataTypeService.php
@@ -14,16 +14,13 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Type;
 
 use Pimcore\Model\DataObject;
 
-class ClassificationStoreDataTypeService
+/**
+ * @internal
+ */
+final class ClassificationStoreDataTypeService
 {
-    /**
-     * @var TransformationDataTypeService
-     */
-    protected $transformationDataTypeService;
-
-    public function __construct(TransformationDataTypeService $transformationDataTypeService)
+    public function __construct(private readonly TransformationDataTypeService $transformationDataTypeService)
     {
-        $this->transformationDataTypeService = $transformationDataTypeService;
     }
 
     public function listClassificationStoreKeyList(string $classId, string $fieldName, string $transformationResultType, string $orderKey = 'name', string $order = 'ASC', int $start = 0, int $limit = 15, ?string $searchString = null, ?string $filterString = null): DataObject\Classificationstore\KeyGroupRelation\Listing

--- a/src/Mapping/Type/TransformationDataTypeService.php
+++ b/src/Mapping/Type/TransformationDataTypeService.php
@@ -15,59 +15,62 @@ namespace Pimcore\Bundle\DataImporterBundle\Mapping\Type;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\DataObject\Objectbrick\Definition;
 
-class TransformationDataTypeService
+/**
+ * @internal
+ */
+final class TransformationDataTypeService
 {
-    const DEFAULT_TYPE = 'default';
+    public const DEFAULT_TYPE = 'default';
 
-    const DEFAULT_ARRAY = 'array';
+    public const DEFAULT_ARRAY = 'array';
 
-    const NUMERIC = 'numeric';
+    public const NUMERIC = 'numeric';
 
-    const BOOLEAN = 'boolean';
+    public const BOOLEAN = 'boolean';
 
-    const QUANTITY_VALUE = 'quantityValue';
+    public const QUANTITY_VALUE = 'quantityValue';
 
-    const QUANTITY_VALUE_ARRAY = 'quantityValueArray';
+    public const QUANTITY_VALUE_ARRAY = 'quantityValueArray';
 
-    const INPUT_QUANTITY_VALUE = 'inputQuantityValue';
+    public const INPUT_QUANTITY_VALUE = 'inputQuantityValue';
 
-    const INPUT_QUANTITY_VALUE_ARRAY = 'inputQuantityValueArray';
+    public const INPUT_QUANTITY_VALUE_ARRAY = 'inputQuantityValueArray';
 
-    const DATE = 'date';
+    public const DATE = 'date';
 
-    const DATE_ARRAY = 'dateArray';
+    public const DATE_ARRAY = 'dateArray';
 
-    const ASSET = 'asset';
+    public const ASSET = 'asset';
 
-    const ASSET_ARRAY = 'assetArray';
+    public const ASSET_ARRAY = 'assetArray';
 
-    const GALLERY = 'gallery';
+    public const GALLERY = 'gallery';
 
-    const IMAGE_ADVANCED = 'imageAdvanced';
+    public const IMAGE_ADVANCED = 'imageAdvanced';
 
-    const DATA_OBJECT = 'dataObject';
+    public const DATA_OBJECT = 'dataObject';
 
-    const DATA_OBJECT_ARRAY = 'dataObjectArray';
+    public const DATA_OBJECT_ARRAY = 'dataObjectArray';
 
-    const ADVANCED_DATA_OBJECT_ARRAY = 'advancedDataObjectArray';
+    public const ADVANCED_DATA_OBJECT_ARRAY = 'advancedDataObjectArray';
 
-    const ADVANCED_ASSET_ARRAY = 'advancedAssetArray';
+    public const ADVANCED_ASSET_ARRAY = 'advancedAssetArray';
 
-    const GEOPOINT_VALUE = 'geoPoint';
+    public const GEOPOINT_VALUE = 'geoPoint';
 
-    const GEOBOUNDS_VALUE = 'geoBounds';
+    public const GEOBOUNDS_VALUE = 'geoBounds';
 
-    const GEOPOLYGON_VALUE = 'geoPolygon';
+    public const GEOPOLYGON_VALUE = 'geoPolygon';
 
-    const GEOPOLYLINE_VALUE = 'geoPolyline';
+    public const GEOPOLYLINE_VALUE = 'geoPolyline';
 
-    const RGBA_COLOR = 'rgbaColor';
+    public const RGBA_COLOR = 'rgbaColor';
 
-    const COUNTRY_ARRAY = 'countryArray';
+    public const COUNTRY_ARRAY = 'countryArray';
 
-    const CALCULATED = 'calculated';
+    public const CALCULATED = 'calculated';
 
-    protected $transformationDataTypesMapping = [
+    private array $transformationDataTypesMapping = [
         self::DEFAULT_TYPE => [
             'input',
             'textarea',
@@ -165,7 +168,7 @@ class TransformationDataTypeService
         $this->transformationDataTypesMapping[$transformationTargetType][] = $pimcoreDataType;
     }
 
-    protected function addTypesToAttributesArray(ClassDefinition\Data $fieldDefinition, string $targetType, array &$attributes, bool $localized = false, ?string $keyPrefix = null)
+    private function addTypesToAttributesArray(ClassDefinition\Data $fieldDefinition, string $targetType, array &$attributes, bool $localized = false, ?string $keyPrefix = null)
     {
         if (in_array($fieldDefinition->getFieldtype(), ($this->transformationDataTypesMapping[$targetType] ?? []))) {
             $key = $fieldDefinition->getName();

--- a/src/Mapping/Type/TransformationDataTypeService.php
+++ b/src/Mapping/Type/TransformationDataTypeService.php
@@ -168,7 +168,13 @@ final class TransformationDataTypeService
         $this->transformationDataTypesMapping[$transformationTargetType][] = $pimcoreDataType;
     }
 
-    private function addTypesToAttributesArray(ClassDefinition\Data $fieldDefinition, string $targetType, array &$attributes, bool $localized = false, ?string $keyPrefix = null)
+    private function addTypesToAttributesArray(
+        ClassDefinition\Data $fieldDefinition,
+        string $targetType,
+        array &$attributes,
+        bool $localized = false,
+        ?string $keyPrefix = null,
+    )
     {
         if (in_array($fieldDefinition->getFieldtype(), ($this->transformationDataTypesMapping[$targetType] ?? []))) {
             $key = $fieldDefinition->getName();

--- a/src/Messenger/DataImporterHandler.php
+++ b/src/Messenger/DataImporterHandler.php
@@ -17,11 +17,14 @@ use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Model\Tool\TmpStore;
 use Symfony\Component\Messenger\MessageBusInterface;
 
-class DataImporterHandler
+/**
+ * @internal
+ */
+final class DataImporterHandler
 {
-    const IMPORTER_WORKER_COUNT_TMP_STORE_KEY_PREFIX = 'DATA-IMPORTER::worker-count::';
+    private const IMPORTER_WORKER_COUNT_TMP_STORE_KEY_PREFIX = 'DATA-IMPORTER::worker-count::';
 
-    protected array $workerCounts = [
+    private array $workerCounts = [
         ImportProcessingService::EXECUTION_TYPE_PARALLEL => 3,
         ImportProcessingService::EXECUTION_TYPE_SEQUENTIAL => 1,
     ];
@@ -35,12 +38,12 @@ class DataImporterHandler
      * @param int $workerCountParallel
      */
     public function __construct(
-        protected QueueService $queueService,
-        protected ImportProcessingService $importProcessingService,
-        protected MessageBusInterface $messageBus,
-        protected int $workerCountLifeTime,
-        protected int $workerItemCount,
-        protected $workerCountParallel
+        private readonly QueueService $queueService,
+        private readonly ImportProcessingService $importProcessingService,
+        private readonly MessageBusInterface $messageBus,
+        private readonly int $workerCountLifeTime,
+        private readonly int $workerItemCount,
+        private readonly int $workerCountParallel,
     ) {
         $this->workerCounts[ImportProcessingService::EXECUTION_TYPE_PARALLEL] = $this->workerCountParallel;
     }

--- a/src/Messenger/DataImporterMessage.php
+++ b/src/Messenger/DataImporterMessage.php
@@ -12,10 +12,16 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Messenger;
 
-class DataImporterMessage
+/**
+ * @internal
+ */
+final readonly class DataImporterMessage
 {
-    public function __construct(protected string $executionType, protected array $ids, protected string $messageId)
-    {
+    public function __construct(
+        private string $executionType,
+        private array $ids,
+        private string $messageId,
+    ) {
     }
 
     public function getExecutionType(): string

--- a/src/Migrations/Version20210305134111.php
+++ b/src/Migrations/Version20210305134111.php
@@ -17,7 +17,10 @@ use Pimcore\Bundle\DataImporterBundle\Installer;
 use Pimcore\Migrations\BundleAwareMigration;
 use Pimcore\Model\Tool\SettingsStore;
 
-class Version20210305134111 extends BundleAwareMigration
+/**
+ * @internal
+ */
+final class Version20210305134111 extends BundleAwareMigration
 {
     protected function getBundleName(): string
     {

--- a/src/Migrations/Version20211110174732.php
+++ b/src/Migrations/Version20211110174732.php
@@ -15,13 +15,16 @@ namespace Pimcore\Bundle\DataImporterBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\BundleAwareMigration;
 
-class Version20211110174732 extends BundleAwareMigration
+/**
+ * @internal
+ */
+final class Version20211110174732 extends BundleAwareMigration
 {
-    protected const DELTA_CACHE_TABLE = 'bundle_data_hub_data_importer_delta_cache';
+    private const DELTA_CACHE_TABLE = 'bundle_data_hub_data_importer_delta_cache';
 
-    protected const LAST_CRON_TABLE = 'bundle_data_hub_data_importer_last_cron_execution';
+    private const LAST_CRON_TABLE = 'bundle_data_hub_data_importer_last_cron_execution';
 
-    protected const IMPORTER_QUEUE_TABLE = 'bundle_data_hub_data_importer_queue';
+    private const IMPORTER_QUEUE_TABLE = 'bundle_data_hub_data_importer_queue';
 
     protected function getBundleName(): string
     {

--- a/src/Migrations/Version20211201173215.php
+++ b/src/Migrations/Version20211201173215.php
@@ -27,11 +27,14 @@ namespace Pimcore\Bundle\DataImporterBundle\Migrations;
 use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Migrations\BundleAwareMigration;
 
+/**
+ * @internal
+ */
 final class Version20211201173215 extends BundleAwareMigration
 {
-    protected const ORIGINAL_NAME = 'bundle_data_hub_data_importer_last_cron_execution';
+    private const ORIGINAL_NAME = 'bundle_data_hub_data_importer_last_cron_execution';
 
-    protected const TARGET_NAME = 'bundle_data_hub_data_importer_last_execution';
+    private const TARGET_NAME = 'bundle_data_hub_data_importer_last_execution';
 
     protected function getBundleName(): string
     {

--- a/src/Migrations/Version20220304130000.php
+++ b/src/Migrations/Version20220304130000.php
@@ -16,7 +16,10 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Migrations\BundleAwareMigration;
 
-class Version20220304130000 extends BundleAwareMigration
+/**
+ * @internal
+ */
+final class Version20220304130000 extends BundleAwareMigration
 {
     public function up(Schema $schema): void
     {

--- a/src/Migrations/Version20240715160305.php
+++ b/src/Migrations/Version20240715160305.php
@@ -16,7 +16,10 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Migrations\BundleAwareMigration;
 
-class Version20240715160305 extends BundleAwareMigration
+/**
+ * @internal
+ */
+final class Version20240715160305 extends BundleAwareMigration
 {
     public function up(Schema $schema): void
     {

--- a/src/Migrations/Version20251003105903.php
+++ b/src/Migrations/Version20251003105903.php
@@ -18,6 +18,9 @@ use Doctrine\DBAL\Schema\Schema;
 use Pimcore\Bundle\DataImporterBundle\Queue\QueueService;
 use Pimcore\Migrations\BundleAwareMigration;
 
+/**
+ * @internal
+ */
 final class Version20251003105903 extends BundleAwareMigration
 {
     public function getDescription(): string

--- a/src/PimcoreDataImporterBundle.php
+++ b/src/PimcoreDataImporterBundle.php
@@ -66,7 +66,7 @@ final class PimcoreDataImporterBundle extends AbstractPimcoreBundle implements D
         );
     }
 
-    public function getInstaller(): ?InstallerInterface
+    public function getInstaller(): InstallerInterface
     {
         return $this->container->get(Installer::class);
     }

--- a/src/PimcoreDataImporterBundle.php
+++ b/src/PimcoreDataImporterBundle.php
@@ -29,11 +29,11 @@ use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
 
-class PimcoreDataImporterBundle extends AbstractPimcoreBundle implements DependentBundleInterface
+final class PimcoreDataImporterBundle extends AbstractPimcoreBundle implements DependentBundleInterface
 {
     use PackageVersionTrait;
 
-    const LOGGER_COMPONENT_PREFIX = 'DATA-IMPORTER ';
+    public const LOGGER_COMPONENT_PREFIX = 'DATA-IMPORTER ';
 
     protected function getComposerPackageName(): string
     {

--- a/src/Preview/Model/PreviewData.php
+++ b/src/Preview/Model/PreviewData.php
@@ -12,41 +12,22 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Preview\Model;
 
-class PreviewData
+/**
+ * @internal
+ */
+final class PreviewData
 {
-    /**
-     * @var array
-     */
-    protected $labels;
-
-    /**
-     * @var array
-     */
-    protected $previewData;
-
-    /**
-     * @var int
-     */
-    protected $recordNumber;
-
-    /**
-     * @var array
-     */
-    protected $mappedColumns;
+    private readonly array $mappedColumns;
 
     /**
      * PreviewData constructor.
-     *
-     * @param array $labels
-     * @param array $previewData
-     * @param int $recordNumber
-     * @param array $mappedColumns
      */
-    public function __construct(array $labels, array $previewData, int $recordNumber, array $mappedColumns = [])
-    {
-        $this->labels = $labels;
-        $this->previewData = $previewData;
-        $this->recordNumber = $recordNumber;
+    public function __construct(
+        private readonly array $labels,
+        private readonly array $previewData,
+        private readonly int $recordNumber,
+        array $mappedColumns = [],
+    ) {
         $this->mappedColumns = array_flip($mappedColumns);
     }
 

--- a/src/Preview/PreviewService.php
+++ b/src/Preview/PreviewService.php
@@ -17,15 +17,16 @@ use Pimcore\Bundle\DataHubBundle\Configuration;
 use Pimcore\Helper\TemporaryFileHelperTrait;
 use Pimcore\Model\User;
 
-class PreviewService
+/**
+ * @internal
+ */
+final class PreviewService
 {
     use TemporaryFileHelperTrait;
 
-    protected FilesystemOperator $pimcoreDataImporterPreviewStorage;
-
-    public function __construct(FilesystemOperator $pimcoreDataImporterPreviewStorage)
-    {
-        $this->pimcoreDataImporterPreviewStorage = $pimcoreDataImporterPreviewStorage;
+    public function __construct(
+        private readonly FilesystemOperator $pimcoreDataImporterPreviewStorage,
+    ) {
     }
 
     public function writePreviewFile(string $configName, string $sourcePath, User $user)
@@ -42,7 +43,7 @@ class PreviewService
      *
      * @throws \Exception
      */
-    protected function getPreviewFilePath(string $configName, User $user): string
+    private function getPreviewFilePath(string $configName, User $user): string
     {
         $configuration = Configuration::getByName($configName);
         if (!$configuration) {

--- a/src/Processing/ExecutionService.php
+++ b/src/Processing/ExecutionService.php
@@ -18,14 +18,17 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Pimcore\Db;
 
-class ExecutionService
+/**
+ * @internal
+ */
+final class ExecutionService
 {
-    const EXECUTION_STORAGE_TABLE_NAME = 'bundle_data_hub_data_importer_last_execution';
+    public const EXECUTION_STORAGE_TABLE_NAME = 'bundle_data_hub_data_importer_last_execution';
 
     /**
      * @return Connection
      */
-    protected function getDb()
+    private function getDb()
     {
         /** @var Connection $db */
         $db = Db::get();
@@ -33,7 +36,7 @@ class ExecutionService
         return $db;
     }
 
-    protected function createTableIfNotExisting()
+    private function createTableIfNotExisting()
     {
         $this->getDb()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (
             configName varchar(80) NOT NULL,

--- a/src/Processing/ImportPreparationService.php
+++ b/src/Processing/ImportPreparationService.php
@@ -32,10 +32,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 final class ImportPreparationService
 {
-    private const SCHEDULE_TYPE_CRON = 'cron';
-
-    private const SCHEDULE_TYPE_JOB = 'job';
-
     use LoggerAwareTrait;
 
     /**

--- a/src/Processing/ImportPreparationService.php
+++ b/src/Processing/ImportPreparationService.php
@@ -27,84 +27,30 @@ use Pimcore\Bundle\DataImporterBundle\Settings\ConfigurationPreparationService;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class ImportPreparationService
+/**
+ * @internal
+ */
+final class ImportPreparationService
 {
-    const SCHEDULE_TYPE_CRON = 'cron';
+    private const SCHEDULE_TYPE_CRON = 'cron';
 
-    const SCHEDULE_TYPE_JOB = 'job';
+    private const SCHEDULE_TYPE_JOB = 'job';
 
     use LoggerAwareTrait;
 
     /**
-     * @var ConfigurationPreparationService
-     */
-    protected $configLoader;
-
-    /**
-     * @var ResolverFactory
-     */
-    protected $resolverFactory;
-
-    /**
-     * @var InterpreterFactory
-     */
-    protected $interpreterFactory;
-
-    /**
-     * @var DataLoaderFactory
-     */
-    protected $dataLoaderFactory;
-
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
-
-    /**
-     * @var ApplicationLogger
-     */
-    protected $applicationLogger;
-
-    /**
-     * @var ExecutionService
-     */
-    protected $executionService;
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    protected $eventDispatcher;
-
-    /**
      * ImportPreparationService constructor.
-     *
-     * @param ResolverFactory $resolverFactory
-     * @param InterpreterFactory $interpreterFactory
-     * @param DataLoaderFactory $dataLoaderFactory
-     * @param QueueService $queueService
-     * @param ApplicationLogger $applicationLogger
-     * @param ConfigurationPreparationService $configurationPreparationService
-     * @param ExecutionService $executionService
-     * @param EventDispatcherInterface $eventDispatcher
      */
     public function __construct(
-        ResolverFactory $resolverFactory,
-        InterpreterFactory $interpreterFactory,
-        DataLoaderFactory $dataLoaderFactory,
-        QueueService $queueService,
-        ApplicationLogger $applicationLogger,
-        ConfigurationPreparationService $configurationPreparationService,
-        ExecutionService $executionService,
-        EventDispatcherInterface $eventDispatcher
+        private readonly ResolverFactory $resolverFactory,
+        private readonly InterpreterFactory $interpreterFactory,
+        private readonly DataLoaderFactory $dataLoaderFactory,
+        private readonly QueueService $queueService,
+        private readonly ApplicationLogger $applicationLogger,
+        private readonly ConfigurationPreparationService $configLoader,
+        private readonly ExecutionService $executionService,
+        private readonly EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->resolverFactory = $resolverFactory;
-        $this->interpreterFactory = $interpreterFactory;
-        $this->dataLoaderFactory = $dataLoaderFactory;
-        $this->queueService = $queueService;
-        $this->applicationLogger = $applicationLogger;
-        $this->configLoader = $configurationPreparationService;
-        $this->executionService = $executionService;
-        $this->eventDispatcher = $eventDispatcher;
     }
 
     public function prepareImport(

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -35,94 +35,56 @@ use Pimcore\Model\Version;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
-class ImportProcessingService
+/**
+ * @internal
+ */
+final class ImportProcessingService
 {
     use LoggerAwareTrait;
 
-    const JOB_TYPE_PROCESS = 'process';
+    public const JOB_TYPE_PROCESS = 'process';
 
-    const JOB_TYPE_CLEANUP = 'cleanup';
+    public const JOB_TYPE_CLEANUP = 'cleanup';
 
-    const EXECUTION_TYPE_SEQUENTIAL = 'sequential';
+    public const EXECUTION_TYPE_SEQUENTIAL = 'sequential';
 
-    const EXECUTION_TYPE_PARALLEL = 'parallel';
+    public const EXECUTION_TYPE_PARALLEL = 'parallel';
 
-    const INFO_ENTRY_ID_PREFIX = 'datahub_dataimporter_';
+    public const INFO_ENTRY_ID_PREFIX = 'datahub_dataimporter_';
 
-    /**
-     * @var QueueService
-     */
-    protected $queueService;
-
-    /**
-     * @var ConfigurationPreparationService
-     */
-    protected $configLoader;
-
-    /**
-     * @var MappingConfigurationFactory
-     */
-    protected $mappingConfigurationFactory;
-
-    /**
-     * @var ResolverFactory
-     */
-    protected $resolverFactory;
-
-    /**
-     * @var CleanupStrategyFactory
-     */
-    protected $cleanupStrategyFactory;
-
-    /**
-     * @var ApplicationLogger
-     */
-    protected $applicationLogger;
+    private ConfigurationPreparationService $configLoader;
 
     /**
      * @var Resolver[]
      */
-    protected $resolverCache = [];
+    private array $resolverCache = [];
 
     /**
      * @var MappingConfiguration[][]
      */
-    protected $mappingConfigurationCache = [];
-
-    /**
-     * @var EventDispatcherInterface
-     */
-    protected $eventDispatcher;
+    private array $mappingConfigurationCache = [];
 
     /**
      * @var array
      */
-    protected $loggingConfigCache = [];
+    private array $loggingConfigCache = [];
 
     /**
      * @var array<string, bool>
      */
-    protected $versioningConfigCache = [];
+    private array $versioningConfigCache = [];
 
     /**
      * ImportProcessingService constructor.
-     *
-     * @param QueueService $queueService
-     * @param MappingConfigurationFactory $mappingConfigurationFactory
-     * @param ResolverFactory $resolverFactory
-     * @param CleanupStrategyFactory $cleanupStrategyFactory
-     * @param ApplicationLogger $applicationLogger
-     * @param EventDispatcherInterface $eventDispatcher
      */
-    public function __construct(QueueService $queueService, MappingConfigurationFactory $mappingConfigurationFactory, ResolverFactory $resolverFactory, CleanupStrategyFactory $cleanupStrategyFactory, ApplicationLogger $applicationLogger, EventDispatcherInterface $eventDispatcher)
-    {
-        $this->queueService = $queueService;
-        $this->mappingConfigurationFactory = $mappingConfigurationFactory;
-        $this->resolverFactory = $resolverFactory;
-        $this->cleanupStrategyFactory = $cleanupStrategyFactory;
-        $this->applicationLogger = $applicationLogger;
-        $this->eventDispatcher = $eventDispatcher;
-
+    public function __construct(
+        private readonly QueueService $queueService,
+        private readonly MappingConfigurationFactory $mappingConfigurationFactory,
+        private readonly ResolverFactory $resolverFactory,
+        private readonly CleanupStrategyFactory $cleanupStrategyFactory,
+        private readonly ApplicationLogger $applicationLogger,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {
         $this->configLoader = new ConfigurationPreparationService();
     }
 
@@ -237,7 +199,7 @@ class ImportProcessingService
      * @param Resolver $resolver
      * @param MappingConfiguration[] $mapping
      */
-    protected function processElement(string $configName, array $importDataRow, Resolver $resolver, array $mapping, int $userOwner)
+    private function processElement(string $configName, array $importDataRow, Resolver $resolver, array $mapping, int $userOwner)
     {
         $element = null;
         $currentMapping = null;
@@ -374,7 +336,7 @@ class ImportProcessingService
         $currentMapping = null; // Success - clear current mapping
     }
 
-    protected function cleanupElement(string $configName, string $identifier, Resolver $resolver, array $cleanupConfig)
+    private function cleanupElement(string $configName, string $identifier, Resolver $resolver, array $cleanupConfig)
     {
         if ($cleanupConfig['doCleanup'] ?? false) {
             $element = null;

--- a/src/Processing/ImportProcessingService.php
+++ b/src/Processing/ImportProcessingService.php
@@ -199,7 +199,13 @@ final class ImportProcessingService
      * @param Resolver $resolver
      * @param MappingConfiguration[] $mapping
      */
-    private function processElement(string $configName, array $importDataRow, Resolver $resolver, array $mapping, int $userOwner)
+    private function processElement(
+        string $configName,
+        array $importDataRow,
+        Resolver $resolver,
+        array $mapping,
+        int $userOwner,
+    )
     {
         $element = null;
         $currentMapping = null;

--- a/src/Processing/Scheduler/CronScheduler.php
+++ b/src/Processing/Scheduler/CronScheduler.php
@@ -15,18 +15,17 @@ namespace Pimcore\Bundle\DataImporterBundle\Processing\Scheduler;
 use Cron\CronExpression;
 use DateTime;
 
-class CronScheduler implements SchedulerInterface
+/**
+ * @internal
+ */
+final class CronScheduler implements SchedulerInterface
 {
-    const NAME = 'cron';
+    public const NAME = 'cron';
 
-    private string $cronDefinition;
-
-    private DateTime $modifiedAt;
-
-    public function __construct(string $cronDefinition, DateTime $modifiedAt)
-    {
-        $this->cronDefinition = $cronDefinition;
-        $this->modifiedAt = $modifiedAt;
+    public function __construct(
+        private readonly string $cronDefinition,
+        private readonly DateTime $modifiedAt,
+    ) {
     }
 
     public function isExecutable(?DateTime $executedAt): bool

--- a/src/Processing/Scheduler/Exception/InvalidScheduleException.php
+++ b/src/Processing/Scheduler/Exception/InvalidScheduleException.php
@@ -14,6 +14,6 @@ namespace Pimcore\Bundle\DataImporterBundle\Processing\Scheduler\Exception;
 
 use Exception;
 
-class InvalidScheduleException extends Exception
+final class InvalidScheduleException extends Exception
 {
 }

--- a/src/Processing/Scheduler/JobScheduler.php
+++ b/src/Processing/Scheduler/JobScheduler.php
@@ -14,18 +14,17 @@ namespace Pimcore\Bundle\DataImporterBundle\Processing\Scheduler;
 
 use DateTime;
 
-class JobScheduler implements SchedulerInterface
+/**
+ * @internal
+ */
+final class JobScheduler implements SchedulerInterface
 {
-    const NAME = 'job';
+    public const NAME = 'job';
 
-    private DateTime $scheduledAt;
-
-    private DateTime $modifiedAt;
-
-    public function __construct(DateTime $scheduledAt, DateTime $modifiedAt)
-    {
-        $this->scheduledAt = $scheduledAt;
-        $this->modifiedAt = $modifiedAt;
+    public function __construct(
+        private readonly DateTime $scheduledAt,
+        private readonly DateTime $modifiedAt,
+    ) {
     }
 
     public function isExecutable(?DateTime $executedAt): bool

--- a/src/Processing/Scheduler/SchedulerFactory.php
+++ b/src/Processing/Scheduler/SchedulerFactory.php
@@ -15,7 +15,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Processing\Scheduler;
 use DateTime;
 use Pimcore\Bundle\DataImporterBundle\Processing\Scheduler\Exception\InvalidScheduleException;
 
-class SchedulerFactory
+/**
+ * @internal
+ */
+final class SchedulerFactory
 {
     /**
      * @throws InvalidScheduleException

--- a/src/Queue/QueueService.php
+++ b/src/Queue/QueueService.php
@@ -18,14 +18,17 @@ use Doctrine\DBAL\Exception;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Pimcore\Db;
 
-class QueueService
+/**
+ * @internal
+ */
+final class QueueService
 {
-    const QUEUE_TABLE_NAME = 'bundle_data_hub_data_importer_queue';
+    private const QUEUE_TABLE_NAME = 'bundle_data_hub_data_importer_queue';
 
     /**
      * @return Connection
      */
-    protected function getDb()
+    private function getDb()
     {
         /** @var Connection $db */
         $db = Db::get();
@@ -33,7 +36,7 @@ class QueueService
         return $db;
     }
 
-    protected function getCurrentQueueTableOperationTime(): int
+    private function getCurrentQueueTableOperationTime(): int
     {
         $carbonNow = Carbon::now();
 
@@ -80,7 +83,7 @@ class QueueService
      *
      * @throws Exception
      */
-    protected function createQueueTableIfNotExisting(?\Closure $callable = null)
+    private function createQueueTableIfNotExisting(?\Closure $callable = null)
     {
         $this->getDb()->executeQuery(sprintf('CREATE TABLE IF NOT EXISTS %s (
             id bigint AUTO_INCREMENT,

--- a/src/Queue/QueueService.php
+++ b/src/Queue/QueueService.php
@@ -23,7 +23,7 @@ use Pimcore\Db;
  */
 final class QueueService
 {
-    private const QUEUE_TABLE_NAME = 'bundle_data_hub_data_importer_queue';
+    public const QUEUE_TABLE_NAME = 'bundle_data_hub_data_importer_queue';
 
     /**
      * @return Connection

--- a/src/Resolver/Factory/DataObjectFactory.php
+++ b/src/Resolver/Factory/DataObjectFactory.php
@@ -18,21 +18,15 @@ use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
 use Pimcore\Model\Factory;
 
-class DataObjectFactory implements FactoryInterface
+/**
+ * @internal
+ */
+final class DataObjectFactory implements FactoryInterface
 {
-    /**
-     * @var string
-     */
-    protected $subType;
+    private string $subType;
 
-    /**
-     * @var Factory
-     */
-    protected $modelFactory;
-
-    public function __construct(Factory $modelFactory)
+    public function __construct(private readonly Factory $modelFactory)
     {
-        $this->modelFactory = $modelFactory;
     }
 
     public function setSubType(string $subType): void

--- a/src/Resolver/Load/AbstractLoad.php
+++ b/src/Resolver/Load/AbstractLoad.php
@@ -18,6 +18,9 @@ use Pimcore\Bundle\DataImporterBundle\Tool\DataObjectLoader;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
 
+/**
+ * @internal
+ */
 abstract class AbstractLoad implements LoadStrategyInterface
 {
     /**

--- a/src/Resolver/Load/AttributeStrategy.php
+++ b/src/Resolver/Load/AttributeStrategy.php
@@ -15,22 +15,16 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Load;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Element\ElementInterface;
 
-class AttributeStrategy extends AbstractLoad
+/**
+ * @internal
+ */
+final class AttributeStrategy extends AbstractLoad
 {
-    /**
-     * @var string
-     */
-    protected $attributeName;
+    private string $attributeName;
 
-    /**
-     * @var string
-     */
-    protected $attributeLanguage;
+    private string $attributeLanguage;
 
-    /**
-     * @var bool
-     */
-    protected $includeUnpublished;
+    private bool $includeUnpublished;
 
     /**
      * @param array $settings

--- a/src/Resolver/Load/IdStrategy.php
+++ b/src/Resolver/Load/IdStrategy.php
@@ -15,7 +15,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Load;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Element\ElementInterface;
 
-class IdStrategy extends AbstractLoad
+/**
+ * @internal
+ */
+final class IdStrategy extends AbstractLoad
 {
     /**
      * @param string $identifier

--- a/src/Resolver/Load/NotLoadStrategy.php
+++ b/src/Resolver/Load/NotLoadStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Load;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class NotLoadStrategy implements LoadStrategyInterface
+/**
+ * @internal
+ */
+final class NotLoadStrategy implements LoadStrategyInterface
 {
     public function loadElement(array $inputData): ?ElementInterface
     {

--- a/src/Resolver/Load/PathStrategy.php
+++ b/src/Resolver/Load/PathStrategy.php
@@ -15,7 +15,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Load;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Element\ElementInterface;
 
-class PathStrategy extends AbstractLoad
+/**
+ * @internal
+ */
+final class PathStrategy extends AbstractLoad
 {
     /**
      * @param string $identifier

--- a/src/Resolver/Location/DoNotCreateStrategy.php
+++ b/src/Resolver/Location/DoNotCreateStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Location;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class DoNotCreateStrategy implements LocationStrategyInterface
+/**
+ * @internal
+ */
+final class DoNotCreateStrategy implements LocationStrategyInterface
 {
     public function updateParent(ElementInterface $element, array $inputData): ElementInterface
     {

--- a/src/Resolver/Location/FindOrCreateFolderStrategy.php
+++ b/src/Resolver/Location/FindOrCreateFolderStrategy.php
@@ -25,15 +25,7 @@ final class FindOrCreateFolderStrategy implements LocationStrategyInterface
 {
     private mixed $dataSourceIndex;
 
-    private string $findStrategy;
-
     private string $fallbackPath;
-
-    private mixed $attributeDataObjectClassId;
-
-    private string $attributeName;
-
-    private string $attributeLanguage;
 
     public function __construct(private readonly DataObjectLoader $dataObjectLoader)
     {
@@ -72,9 +64,5 @@ final class FindOrCreateFolderStrategy implements LocationStrategyInterface
         }
 
         return $element->setParent($newParent);
-    }
-
-    private function loadById()
-    {
     }
 }

--- a/src/Resolver/Location/FindOrCreateFolderStrategy.php
+++ b/src/Resolver/Location/FindOrCreateFolderStrategy.php
@@ -18,39 +18,24 @@ use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\Element\ElementInterface;
 
-class FindOrCreateFolderStrategy implements LocationStrategyInterface
+/**
+ * @internal
+ */
+final class FindOrCreateFolderStrategy implements LocationStrategyInterface
 {
-    /**
-     * @var mixed
-     */
-    protected $dataSourceIndex;
+    private mixed $dataSourceIndex;
 
-    /**
-     * @var string
-     */
-    protected $findStrategy;
+    private string $findStrategy;
 
-    /**
-     * @var string
-     */
-    protected $fallbackPath;
+    private string $fallbackPath;
 
-    /**
-     * @var mixed
-     */
-    protected $attributeDataObjectClassId;
+    private mixed $attributeDataObjectClassId;
 
-    /**
-     * @var string
-     */
-    protected $attributeName;
+    private string $attributeName;
 
-    /**
-     * @var string
-     */
-    protected $attributeLanguage;
+    private string $attributeLanguage;
 
-    public function __construct(protected DataObjectLoader $dataObjectLoader)
+    public function __construct(private readonly DataObjectLoader $dataObjectLoader)
     {
     }
 
@@ -89,7 +74,7 @@ class FindOrCreateFolderStrategy implements LocationStrategyInterface
         return $element->setParent($newParent);
     }
 
-    protected function loadById()
+    private function loadById()
     {
     }
 }

--- a/src/Resolver/Location/FindParentStrategy.php
+++ b/src/Resolver/Location/FindParentStrategy.php
@@ -21,47 +21,32 @@ use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Element\ElementInterface;
 
-class FindParentStrategy implements LocationStrategyInterface
+/**
+ * @internal
+ */
+final class FindParentStrategy implements LocationStrategyInterface
 {
-    const FIND_BY_ID = 'id';
+    private const FIND_BY_ID = 'id';
 
-    const FIND_BY_PATH = 'path';
+    private const FIND_BY_PATH = 'path';
 
-    const FIND_BY_ATTRIBUTE = 'attribute';
+    private const FIND_BY_ATTRIBUTE = 'attribute';
 
-    /**
-     * @var mixed
-     */
-    protected $dataSourceIndex;
+    private mixed $dataSourceIndex;
 
-    /**
-     * @var string
-     */
-    protected $findStrategy;
+    private string $findStrategy;
 
-    /**
-     * @var string
-     */
-    protected $fallbackPath;
+    private string $fallbackPath;
 
-    /**
-     * @var mixed
-     */
-    protected $attributeDataObjectClassId;
+    private mixed $attributeDataObjectClassId;
 
-    /**
-     * @var string
-     */
-    protected $attributeName;
+    private string $attributeName;
 
-    /**
-     * @var string
-     */
-    protected $attributeLanguage;
+    private string $attributeLanguage;
 
-    protected bool $saveAsVariant = false;
+    private bool $saveAsVariant = false;
 
-    public function __construct(protected DataObjectLoader $dataObjectLoader)
+    public function __construct(private readonly DataObjectLoader $dataObjectLoader)
     {
     }
 
@@ -158,7 +143,7 @@ class FindParentStrategy implements LocationStrategyInterface
         return $element;
     }
 
-    protected function loadById()
+    private function loadById()
     {
     }
 

--- a/src/Resolver/Location/FindParentStrategy.php
+++ b/src/Resolver/Location/FindParentStrategy.php
@@ -143,10 +143,6 @@ final class FindParentStrategy implements LocationStrategyInterface
         return $element;
     }
 
-    private function loadById()
-    {
-    }
-
     /**
      * @throws InvalidInputException
      */

--- a/src/Resolver/Location/NoChangeStrategy.php
+++ b/src/Resolver/Location/NoChangeStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Location;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class NoChangeStrategy implements LocationStrategyInterface
+/**
+ * @internal
+ */
+final class NoChangeStrategy implements LocationStrategyInterface
 {
     public function updateParent(ElementInterface $element, array $inputData): ElementInterface
     {

--- a/src/Resolver/Location/StaticPathStrategy.php
+++ b/src/Resolver/Location/StaticPathStrategy.php
@@ -16,12 +16,12 @@ use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\DataObject\Service;
 use Pimcore\Model\Element\ElementInterface;
 
-class StaticPathStrategy implements LocationStrategyInterface
+/**
+ * @internal
+ */
+final class StaticPathStrategy implements LocationStrategyInterface
 {
-    /**
-     * @var string
-     */
-    protected $path;
+    private string $path;
 
     public function setSettings(array $settings): void
     {

--- a/src/Resolver/Publish/AlwaysPublishStrategy.php
+++ b/src/Resolver/Publish/AlwaysPublishStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Publish;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class AlwaysPublishStrategy implements PublishStrategyInterface
+/**
+ * @internal
+ */
+final class AlwaysPublishStrategy implements PublishStrategyInterface
 {
     public function setSettings(array $settings): void
     {

--- a/src/Resolver/Publish/AttributeBasedStrategy.php
+++ b/src/Resolver/Publish/AttributeBasedStrategy.php
@@ -15,12 +15,12 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Publish;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Model\Element\ElementInterface;
 
-class AttributeBasedStrategy implements PublishStrategyInterface
+/**
+ * @internal
+ */
+final class AttributeBasedStrategy implements PublishStrategyInterface
 {
-    /**
-     * @var mixed
-     */
-    protected $dataSourceIndex;
+    private mixed $dataSourceIndex;
 
     public function setSettings(array $settings): void
     {

--- a/src/Resolver/Publish/NoChangePublishNewStrategy.php
+++ b/src/Resolver/Publish/NoChangePublishNewStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Publish;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class NoChangePublishNewStrategy implements PublishStrategyInterface
+/**
+ * @internal
+ */
+final class NoChangePublishNewStrategy implements PublishStrategyInterface
 {
     public function setSettings(array $settings): void
     {

--- a/src/Resolver/Publish/NoChangeUnpublishNewStrategy.php
+++ b/src/Resolver/Publish/NoChangeUnpublishNewStrategy.php
@@ -14,7 +14,10 @@ namespace Pimcore\Bundle\DataImporterBundle\Resolver\Publish;
 
 use Pimcore\Model\Element\ElementInterface;
 
-class NoChangeUnpublishNewStrategy implements PublishStrategyInterface
+/**
+ * @internal
+ */
+final class NoChangeUnpublishNewStrategy implements PublishStrategyInterface
 {
     public function setSettings(array $settings): void
     {

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -20,37 +20,22 @@ use Pimcore\Bundle\DataImporterBundle\Resolver\Publish\PublishStrategyInterface;
 use Pimcore\Model\DataObject\AbstractObject;
 use Pimcore\Model\Element\ElementInterface;
 
-class Resolver
+/**
+ * @internal
+ */
+final class Resolver
 {
-    /**
-     * @var string
-     */
-    protected $dataObjectClassId;
+    private string $dataObjectClassId;
 
-    /**
-     * @var LoadStrategyInterface
-     */
-    protected $loadingStrategy;
+    private LoadStrategyInterface $loadingStrategy;
 
-    /**
-     * @var LocationStrategyInterface
-     */
-    protected $locationUpdateStrategy;
+    private LocationStrategyInterface $locationUpdateStrategy;
 
-    /**
-     * @var LocationStrategyInterface
-     */
-    protected $createLocationStrategy;
+    private LocationStrategyInterface $createLocationStrategy;
 
-    /**
-     * @var PublishStrategyInterface
-     */
-    protected $publishingStrategy;
+    private PublishStrategyInterface $publishingStrategy;
 
-    /**
-     * @var FactoryInterface
-     */
-    protected $elementFactory;
+    private FactoryInterface $elementFactory;
 
     /**
      * @return string

--- a/src/Resolver/ResolverFactory.php
+++ b/src/Resolver/ResolverFactory.php
@@ -18,33 +18,11 @@ use Pimcore\Bundle\DataImporterBundle\Resolver\Load\LoadStrategyInterface;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Location\LocationStrategyInterface;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Publish\PublishStrategyInterface;
 
-class ResolverFactory
+/**
+ * @internal
+ */
+final class ResolverFactory
 {
-    /**
-     * @var Resolver
-     */
-    protected $resolverBlueprint;
-
-    /**
-     * @var LoadStrategyInterface[]
-     */
-    protected $loadingStrategyBlueprints;
-
-    /**
-     * @var LocationStrategyInterface[]
-     */
-    protected $locationStrategyBlueprints;
-
-    /**
-     * @var PublishStrategyInterface[]
-     */
-    protected $publishingStrategyBlueprints;
-
-    /**
-     * @var FactoryInterface[]
-     */
-    protected $factoryBlueprints;
-
     /**
      * ResolverFactory constructor.
      *
@@ -54,13 +32,13 @@ class ResolverFactory
      * @param PublishStrategyInterface[] $publishingStrategyBlueprints
      * @param FactoryInterface[] $factoryBlueprints
      */
-    public function __construct(Resolver $resolverBlueprint, array $loadingStrategyBlueprints, array $locationStrategyBlueprints, array $publishingStrategyBlueprints, array $factoryBlueprints)
-    {
-        $this->resolverBlueprint = $resolverBlueprint;
-        $this->loadingStrategyBlueprints = $loadingStrategyBlueprints;
-        $this->locationStrategyBlueprints = $locationStrategyBlueprints;
-        $this->publishingStrategyBlueprints = $publishingStrategyBlueprints;
-        $this->factoryBlueprints = $factoryBlueprints;
+    public function __construct(
+        private readonly Resolver $resolverBlueprint,
+        private readonly array $loadingStrategyBlueprints,
+        private readonly array $locationStrategyBlueprints,
+        private readonly array $publishingStrategyBlueprints,
+        private readonly array $factoryBlueprints,
+    ) {
     }
 
     /**
@@ -71,7 +49,7 @@ class ResolverFactory
      *
      * @throws InvalidConfigurationException
      */
-    protected function buildLoadingStrategy(array $config, $classId): LoadStrategyInterface
+    private function buildLoadingStrategy(array $config, $classId): LoadStrategyInterface
     {
         if (empty($config['type']) || !array_key_exists($config['type'], $this->loadingStrategyBlueprints)) {
             throw new InvalidConfigurationException('Unknown loading strategy type `' . ($config['type'] ?? '') . '`');
@@ -84,7 +62,7 @@ class ResolverFactory
         return $loadingStrategy;
     }
 
-    protected function buildLocationStrategy(array $config): LocationStrategyInterface
+    private function buildLocationStrategy(array $config): LocationStrategyInterface
     {
         if (empty($config['type']) || !array_key_exists($config['type'], $this->locationStrategyBlueprints)) {
             throw new InvalidConfigurationException('Unknown location strategy type `' . ($config['type'] ?? '') . '`');
@@ -96,7 +74,7 @@ class ResolverFactory
         return $locationStrategy;
     }
 
-    protected function buildPublishingStrategy(array $config): PublishStrategyInterface
+    private function buildPublishingStrategy(array $config): PublishStrategyInterface
     {
         if (empty($config['type']) || !array_key_exists($config['type'], $this->publishingStrategyBlueprints)) {
             throw new InvalidConfigurationException('Unknown publishing strategy type `' . ($config['type'] ?? '') . '`');
@@ -108,7 +86,7 @@ class ResolverFactory
         return $publishStrategy;
     }
 
-    protected function buildElementFactory(string $type, ?string $subType = null): FactoryInterface
+    private function buildElementFactory(string $type, ?string $subType = null): FactoryInterface
     {
         if (empty($type) || !array_key_exists($type, $this->factoryBlueprints)) {
             throw new InvalidConfigurationException('Unknown publishing strategy type `' . $type . '`');

--- a/src/Settings/ConfigurationPreparationService.php
+++ b/src/Settings/ConfigurationPreparationService.php
@@ -16,7 +16,10 @@ use Pimcore\Bundle\DataHubBundle\Configuration;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-class ConfigurationPreparationService
+/**
+ * @internal
+ */
+final class ConfigurationPreparationService
 {
     /**
      * @param string $configName

--- a/src/Tool/DataObjectLoader.php
+++ b/src/Tool/DataObjectLoader.php
@@ -16,15 +16,18 @@ use Pimcore\Db;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\Element\ElementInterface;
 
-class DataObjectLoader
+/**
+ * @internal
+ */
+final class DataObjectLoader
 {
-    const CLASS_FIELD_NAME = 'classFieldName';
+    private const CLASS_FIELD_NAME = 'classFieldName';
 
-    const BRICK_NAME = 'brickName';
+    private const BRICK_NAME = 'brickName';
 
-    const BRICK_ATTRIBUTE_NAME = 'brickFieldName';
+    private const BRICK_ATTRIBUTE_NAME = 'brickFieldName';
 
-    const BRICK_ATTRIBUTE_SEPARATOR = '.';
+    private const BRICK_ATTRIBUTE_SEPARATOR = '.';
 
     private function isObjectBrickAttribute(string $attributeName): bool
     {


### PR DESCRIPTION
## Summary

- Apply `@internal` and `final` annotations across **122 files** in the data-importer bundle
- Modernize codebase with PHP 8 features: constructor promotion, `readonly` properties/classes, explicit constant visibility, and type declarations

## Changes

### Annotations
- **`@internal`** added to non-public-API classes (DI, CompilerPasses, Commands, Services, Factories, etc.)
- **`final`** added to concrete classes that are not extended within the package
- **Event classes**: `final` but NOT `@internal` — they are public API that users listen to
- **Exception classes**: `final` only, NOT `@internal` — they are public API that users catch
- **Abstract classes**: `@internal` but NOT `final`, visibility kept as `protected`
- **Public extension point interfaces** left unchanged (not `@internal`): `SettingsAwareInterface`, `CleanupStrategyInterface`, `InterpreterInterface`, `DataLoaderInterface`, `DataTargetInterface`, `OperatorInterface`, `FactoryInterface`, `LoadStrategyInterface`, `LocationStrategyInterface`, `PublishStrategyInterface`, `SchedulerInterface`

### PHP 8 Modernization
- **Constructor promotion** where constructors just assign parameters to properties
- **`protected` → `private`** on final classes (properties, methods, constructor params)
- **`readonly`** on properties only written in constructor and never reassigned
- **`readonly class`** where ALL properties are readonly and no constants exist
- **Explicit constant visibility** on final classes (`const` → `public const` / `private const`)
- **Type declarations** added to properties where constructor parameters already have type hints

### Inheritance Chains Preserved (parent NOT final)
- `JsonFileInterpreter` ← `SqlFileInterpreter`
- `Direct` (DataTarget) ← `ManyToManyRelation`
- `QuantityValue` ← `InputQuantityValue` / `QuantityValueArray` ← `InputQuantityValueArray`
- `ImportAsset` ← `LoadAsset`
- `AbstractLoad` ← `AttributeStrategy`, `IdStrategy`, `PathStrategy`
- `AbstractOperator` / `GeopolyAbstractOperator` ← operator subclasses
- `AbstractInterpreter` ← interpreter subclasses
- `ParallelizationAbstractCommand` ← `ParallelProcessQueueCommand`
- `AbstractDataObjectImportEvent` ← `PostSaveEvent`, `PreSaveEvent`, `ProcessElementExceptionEvent`

## Stats

- **122 files changed**
- **783 insertions, 1030 deletions** (net reduction of 247 lines through constructor promotion)