### PR TITLE
3207 - [Data Importer] - Remove unnecessary quotes from translation YAML files

### DIFF
--- a/src/Resources/translations/studio.en.yaml
+++ b/src/Resources/translations/studio.en.yaml
@@ -1,316 +1,316 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'General'
-data-importer.tabs.permissions: 'Permissions'
-data-importer.tabs.data-setup: 'Data Setup'
-data-importer.tabs.import-logs: 'Import Logs'
-data-importer.tabs.execution: 'Execution'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: General
+data-importer.tabs.permissions: Permissions
+data-importer.tabs.data-setup: Data Setup
+data-importer.tabs.import-logs: Import Logs
+data-importer.tabs.execution: Execution
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Data Source'
-data-importer.data-setup.steps.data-source.description: 'Configure data source and file format'
-data-importer.data-setup.steps.preview-import.title: 'Preview Import'
-data-importer.data-setup.steps.preview-import.description: 'Preview the data to be imported'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Configure data resolution rules'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Map source fields to target fields'
-data-importer.data-setup.steps.processing-settings.title: 'Processing Settings'
-data-importer.data-setup.steps.processing-settings.description: 'Configure import processing settings'
+data-importer.data-setup.steps.data-source.title: Data Source
+data-importer.data-setup.steps.data-source.description: Configure data source and file format
+data-importer.data-setup.steps.preview-import.title: Preview Import
+data-importer.data-setup.steps.preview-import.description: Preview the data to be imported
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Configure data resolution rules
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Map source fields to target fields
+data-importer.data-setup.steps.processing-settings.title: Processing Settings
+data-importer.data-setup.steps.processing-settings.description: Configure import processing settings
 
 # Data Source
-data-importer.data-source.title: 'Data Source'
-data-importer.data-source.type: 'Type'
-data-importer.data-source.type-label: 'Data Source Type'
+data-importer.data-source.title: Data Source
+data-importer.data-source.type: Type
+data-importer.data-source.type-label: Data Source Type
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
-data-importer.loader.asset.asset-path: 'Asset Path'
+data-importer.loader.asset.asset-path: Asset Path
 
 # Upload Loader
-data-importer.loader.upload.status: 'Upload Status'
-data-importer.loader.upload.file-uploaded: 'File uploaded successfully'
-data-importer.loader.upload.no-file: 'No file uploaded yet'
-data-importer.loader.upload.file-path: 'Uploaded file path'
-data-importer.loader.upload.open-upload: 'Upload File'
-data-importer.loader.upload.modal-title: 'Upload Import File'
+data-importer.loader.upload.status: Upload Status
+data-importer.loader.upload.file-uploaded: File uploaded successfully
+data-importer.loader.upload.no-file: No file uploaded yet
+data-importer.loader.upload.file-path: Uploaded file path
+data-importer.loader.upload.open-upload: Upload File
+data-importer.loader.upload.modal-title: Upload Import File
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Host'
-data-importer.loader.sftp.port: 'Port'
-data-importer.loader.sftp.username: 'Username'
-data-importer.loader.sftp.password: 'Password'
-data-importer.loader.sftp.remote-path: 'Remote Path'
+data-importer.loader.sftp.host: Host
+data-importer.loader.sftp.port: Port
+data-importer.loader.sftp.username: Username
+data-importer.loader.sftp.password: Password
+data-importer.loader.sftp.remote-path: Remote Path
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Generate API Key'
-data-importer.loader.push.api-key-required: 'Please enter an API key'
-data-importer.loader.push.api-key-min-length: 'API key must be at least 16 characters long'
-data-importer.loader.push.ignore-not-empty-queue: 'Ignore Not Empty Queue'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Generate API Key
+data-importer.loader.push.api-key-required: Please enter an API key
+data-importer.loader.push.api-key-min-length: API key must be at least 16 characters long
+data-importer.loader.push.ignore-not-empty-queue: Ignore Not Empty Queue
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Database Connection'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Database Connection
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'File Format'
-data-importer.file-format.type: 'Type'
+data-importer.file-format.title: File Format
+data-importer.file-format.type: Type
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Delimiter'
-data-importer.interpreter.csv.enclosure: 'Enclosure'
-data-importer.interpreter.csv.escape: 'Escape Character'
+data-importer.interpreter.csv.delimiter: Delimiter
+data-importer.interpreter.csv.enclosure: Enclosure
+data-importer.interpreter.csv.escape: Escape Character
 data-importer.interpreter.csv.required: '{{field}} is required'
 data-importer.interpreter.csv.single-char-only: '{{field}} must be empty or a single character'
-data-importer.interpreter.csv.skip-first-row: 'Skip First Row'
-data-importer.interpreter.csv.save-header-name: 'Save Header Name'
+data-importer.interpreter.csv.skip-first-row: Skip First Row
+data-importer.interpreter.csv.save-header-name: Save Header Name
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Path'
+data-importer.interpreter.json.path: Path
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Sheet Name'
-data-importer.interpreter.xlsx.skip-first-row: 'Skip First Row'
+data-importer.interpreter.xlsx.sheet-name: Sheet Name
+data-importer.interpreter.xlsx.skip-first-row: Skip First Row
 
 # SQL Interpreter
-data-importer.interpreter.sql.info: 'SQL interpreter uses the query configuration from the SQL loader.'
+data-importer.interpreter.sql.info: SQL interpreter uses the query configuration from the SQL loader.
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Data Object Class'
-data-importer.resolver.class-placeholder: 'Select class'
-data-importer.resolver.element-loading: 'Element Loading'
-data-importer.resolver.loading-strategy: 'Loading Strategy'
-data-importer.resolver.loading-strategy.tooltip: 'Defines how existing elements are matched before import. If no element is found, creation rules are applied.'
-data-importer.resolver.loading-strategy.notLoad: 'No Loading'
-data-importer.resolver.loading-strategy.id: 'Id'
-data-importer.resolver.loading-strategy.path: 'Path'
-data-importer.resolver.loading-strategy.attribute: 'Attribute'
-data-importer.resolver.loading-strategy.attribute-name: 'Attribute Name'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Select attribute'
-data-importer.resolver.loading-strategy.data-source-index: 'Data Source Index'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Select column'
-data-importer.resolver.loading-strategy.language: 'Language'
-data-importer.resolver.loading-strategy.language-placeholder: 'Select language'
-data-importer.resolver.loading-strategy.include-unpublished: 'Include unpublished objects'
-data-importer.resolver.element-creation: 'Element Creation'
-data-importer.resolver.create-location-strategy: 'Location Strategy'
-data-importer.resolver.create-location-strategy.tooltip: 'Controls where newly created elements are placed when no existing element was resolved.'
-data-importer.resolver.location-strategy.staticPath: 'Static Path'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Find or Create Folder'
-data-importer.resolver.location-strategy.findParent: 'Find Parent'
-data-importer.resolver.location-strategy.doNotCreate: 'Do Not Create'
-data-importer.resolver.location-strategy.noChange: 'No Change'
-data-importer.resolver.location-strategy.path: 'Path'
-data-importer.resolver.location-strategy.path-placeholder: 'Enter path'
-data-importer.resolver.location-strategy.data-source-index: 'Data Source Index'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Select column'
-data-importer.resolver.location-strategy.fallback-path: 'Fallback Path'
-data-importer.resolver.location-strategy.fallback-path.tooltip: 'Used when a dynamic target location cannot be resolved from the source data.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Enter fallback path'
-data-importer.resolver.location-strategy.find-strategy: 'Find Strategy'
-data-importer.resolver.location-strategy.find-strategy.id: 'By ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'By Path'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'By Attribute'
-data-importer.resolver.location-strategy.attribute-class: 'Class'
-data-importer.resolver.location-strategy.attribute-name: 'Attribute Name'
-data-importer.resolver.location-strategy.attribute-language: 'Language'
-data-importer.resolver.location-strategy.as-variant: 'As Variant'
-data-importer.resolver.element-location-update: 'Element Location Update'
-data-importer.resolver.location-update-strategy: 'Location Strategy'
-data-importer.resolver.location-update-strategy.tooltip: 'Controls whether and how the location of already resolved elements is changed during import.'
-data-importer.resolver.element-publishing: 'Element Publishing'
-data-importer.resolver.publishing-strategy: 'Publish Strategy'
-data-importer.resolver.publishing-strategy.tooltip: 'Defines publish or unpublish behavior for imported elements.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'No Change / Unpublish New'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'No Change / Publish New'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Always Publish'
-data-importer.resolver.publishing-strategy.attributeBased: 'Attribute Based'
-data-importer.resolver.publishing-strategy.data-source-index: 'Data Source Index'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Select column'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Data Object Class
+data-importer.resolver.class-placeholder: Select class
+data-importer.resolver.element-loading: Element Loading
+data-importer.resolver.loading-strategy: Loading Strategy
+data-importer.resolver.loading-strategy.tooltip: Defines how existing elements are matched before import. If no element is found, creation rules are applied.
+data-importer.resolver.loading-strategy.notLoad: No Loading
+data-importer.resolver.loading-strategy.id: Id
+data-importer.resolver.loading-strategy.path: Path
+data-importer.resolver.loading-strategy.attribute: Attribute
+data-importer.resolver.loading-strategy.attribute-name: Attribute Name
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Select attribute
+data-importer.resolver.loading-strategy.data-source-index: Data Source Index
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Select column
+data-importer.resolver.loading-strategy.language: Language
+data-importer.resolver.loading-strategy.language-placeholder: Select language
+data-importer.resolver.loading-strategy.include-unpublished: Include unpublished objects
+data-importer.resolver.element-creation: Element Creation
+data-importer.resolver.create-location-strategy: Location Strategy
+data-importer.resolver.create-location-strategy.tooltip: Controls where newly created elements are placed when no existing element was resolved.
+data-importer.resolver.location-strategy.staticPath: Static Path
+data-importer.resolver.location-strategy.findOrCreateFolder: Find or Create Folder
+data-importer.resolver.location-strategy.findParent: Find Parent
+data-importer.resolver.location-strategy.doNotCreate: Do Not Create
+data-importer.resolver.location-strategy.noChange: No Change
+data-importer.resolver.location-strategy.path: Path
+data-importer.resolver.location-strategy.path-placeholder: Enter path
+data-importer.resolver.location-strategy.data-source-index: Data Source Index
+data-importer.resolver.location-strategy.data-source-index-placeholder: Select column
+data-importer.resolver.location-strategy.fallback-path: Fallback Path
+data-importer.resolver.location-strategy.fallback-path.tooltip: Used when a dynamic target location cannot be resolved from the source data.
+data-importer.resolver.location-strategy.fallback-path-placeholder: Enter fallback path
+data-importer.resolver.location-strategy.find-strategy: Find Strategy
+data-importer.resolver.location-strategy.find-strategy.id: By ID
+data-importer.resolver.location-strategy.find-strategy.path: By Path
+data-importer.resolver.location-strategy.find-strategy.attribute: By Attribute
+data-importer.resolver.location-strategy.attribute-class: Class
+data-importer.resolver.location-strategy.attribute-name: Attribute Name
+data-importer.resolver.location-strategy.attribute-language: Language
+data-importer.resolver.location-strategy.as-variant: As Variant
+data-importer.resolver.element-location-update: Element Location Update
+data-importer.resolver.location-update-strategy: Location Strategy
+data-importer.resolver.location-update-strategy.tooltip: Controls whether and how the location of already resolved elements is changed during import.
+data-importer.resolver.element-publishing: Element Publishing
+data-importer.resolver.publishing-strategy: Publish Strategy
+data-importer.resolver.publishing-strategy.tooltip: Defines publish or unpublish behavior for imported elements.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: No Change / Unpublish New
+data-importer.resolver.publishing-strategy.noChangePublishNew: No Change / Publish New
+data-importer.resolver.publishing-strategy.alwaysPublish: Always Publish
+data-importer.resolver.publishing-strategy.attributeBased: Attribute Based
+data-importer.resolver.publishing-strategy.data-source-index: Data Source Index
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Select column
 
 # Processing Settings
-data-importer.processing.title: 'Processing Settings'
-data-importer.processing.execution.title: 'Execution'
-data-importer.processing.id-delta.title: 'ID, Delta Check & Cleanup'
-data-importer.processing.execution-type: 'Execution Type'
-data-importer.processing.execution-type.tooltip: 'Sequential runs one item after another. Parallel processes multiple items concurrently.'
-data-importer.processing.execution-type.sequential: 'Sequential'
-data-importer.processing.execution-type.parallel: 'Parallel'
-data-importer.processing.archive-import-file: 'Archive Import File'
-data-importer.processing.disable-versioning: 'Disable Versioning'
-data-importer.processing.id-data-index: 'Data index of ID field'
-data-importer.processing.id-data-index.tooltip: 'Column used as stable identifier for Delta Check and Cleanup. These options are only available when an ID data index is set.'
-data-importer.processing.id-data-index-placeholder: 'Select column'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Cleanup'
-data-importer.processing.cleanup.do-cleanup: 'Cleanup Not Imported Elements'
-data-importer.processing.cleanup.strategy: 'Cleanup Strategy'
-data-importer.processing.cleanup.strategy.tooltip: 'Determines what happens to existing elements that are not present in the current import.'
-data-importer.processing.cleanup.strategy.delete: 'Delete'
-data-importer.processing.cleanup.strategy.unpublish: 'Unpublish'
-data-importer.processing.logging.title: 'Logging Settings (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Disable Info Logs'
-data-importer.processing.logging.info.disable-file-objects: 'Disable Info File Objects'
-data-importer.processing.logging.error.title: 'Error'
-data-importer.processing.logging.error.disable-logs: 'Disable Error Logs'
-data-importer.processing.logging.error.disable-file-objects: 'Disable Error File Objects'
+data-importer.processing.title: Processing Settings
+data-importer.processing.execution.title: Execution
+data-importer.processing.id-delta.title: ID, Delta Check & Cleanup
+data-importer.processing.execution-type: Execution Type
+data-importer.processing.execution-type.tooltip: Sequential runs one item after another. Parallel processes multiple items concurrently.
+data-importer.processing.execution-type.sequential: Sequential
+data-importer.processing.execution-type.parallel: Parallel
+data-importer.processing.archive-import-file: Archive Import File
+data-importer.processing.disable-versioning: Disable Versioning
+data-importer.processing.id-data-index: Data index of ID field
+data-importer.processing.id-data-index.tooltip: Column used as stable identifier for Delta Check and Cleanup. These options are only available when an ID data index is set.
+data-importer.processing.id-data-index-placeholder: Select column
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Cleanup
+data-importer.processing.cleanup.do-cleanup: Cleanup Not Imported Elements
+data-importer.processing.cleanup.strategy: Cleanup Strategy
+data-importer.processing.cleanup.strategy.tooltip: Determines what happens to existing elements that are not present in the current import.
+data-importer.processing.cleanup.strategy.delete: Delete
+data-importer.processing.cleanup.strategy.unpublish: Unpublish
+data-importer.processing.logging.title: Logging Settings (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Disable Info Logs
+data-importer.processing.logging.info.disable-file-objects: Disable Info File Objects
+data-importer.processing.logging.error.title: Error
+data-importer.processing.logging.error.disable-logs: Disable Error Logs
+data-importer.processing.logging.error.disable-file-objects: Disable Error File Objects
 
 # Preview Import
-data-importer.preview-import.title: 'Import Preview'
-data-importer.preview-import.choose-preview-data: 'Choose Preview data'
-data-importer.preview-import.upload-file: 'Upload file'
-data-importer.preview-import.copy-from-source: 'Copy from data source'
-data-importer.preview-import.search-placeholder: 'Search for name, source, destination'
-data-importer.preview-import.column.label: 'Label'
-data-importer.preview-import.column.data: 'Data'
-data-importer.preview-import.prev: 'Previous record'
-data-importer.preview-import.next: 'Next record'
+data-importer.preview-import.title: Import Preview
+data-importer.preview-import.choose-preview-data: Choose Preview data
+data-importer.preview-import.upload-file: Upload file
+data-importer.preview-import.copy-from-source: Copy from data source
+data-importer.preview-import.search-placeholder: Search for name, source, destination
+data-importer.preview-import.column.label: Label
+data-importer.preview-import.column.data: Data
+data-importer.preview-import.prev: Previous record
+data-importer.preview-import.next: Next record
 
 # Mapping
-data-importer.mapping.title: 'Mapping Configuration'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'New'
-data-importer.mapping.new-modal.title: 'New Mapping'
-data-importer.mapping.new-modal.source-label: 'Source column'
-data-importer.mapping.new-modal.source-required: 'Please select a source column'
-data-importer.mapping.collapse-all: 'Collapse all'
-data-importer.mapping.expand-all: 'Expand all'
-data-importer.mapping.auto-fill: 'Autofill'
-data-importer.mapping.empty-state: 'Start creating a mapping directly from the Sources column, or click New to create one manually.'
+data-importer.mapping.title: Mapping Configuration
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: New
+data-importer.mapping.new-modal.title: New Mapping
+data-importer.mapping.new-modal.source-label: Source column
+data-importer.mapping.new-modal.source-required: Please select a source column
+data-importer.mapping.collapse-all: Collapse all
+data-importer.mapping.expand-all: Expand all
+data-importer.mapping.auto-fill: Autofill
+data-importer.mapping.empty-state: Start creating a mapping directly from the Sources column, or click New to create one manually.
 data-importer.mapping.filter-empty: 'No mappings for "{{source}}" yet.'
-data-importer.mapping.sources.title: 'Sources with preview'
-data-importer.mapping.sources.reset-view: 'Reset view'
-data-importer.mapping.sources.empty: 'No preview data available. Please configure a data source and run a preview import first.'
-data-importer.mapping.item.new-label: 'New Mapping'
-data-importer.mapping.item.label: 'Label'
-data-importer.mapping.item.advanced: 'Advanced'
-data-importer.mapping.item.delete: 'Delete mapping'
-data-importer.mapping.item.source: 'Source'
-data-importer.mapping.item.source-placeholder: 'Select source columns'
-data-importer.mapping.item.destination: 'Destination'
-data-importer.mapping.item.destination-placeholder: 'Select field'
-data-importer.mapping.item.requires-advanced-setup: 'Requires advanced setup'
-data-importer.mapping.item.data-source-index: 'Data Source Index'
-data-importer.mapping.item.data-source-index-placeholder: 'Select source columns'
-data-importer.mapping.item.transformation-pipeline.title: 'Transformation Pipeline'
-data-importer.mapping.item.transformation-pipeline.empty: 'No transformation pipeline configured'
-data-importer.mapping.item.transformation-result.title: 'Transformation Result'
-data-importer.mapping.item.transformation-result.type: 'Result Type'
-data-importer.mapping.item.data-target.title: 'Data Target'
-data-importer.mapping.item.data-target.type: 'Target Type'
-data-importer.mapping.item.data-target.type-placeholder: 'Select target type'
-data-importer.mapping.item.data-target.type.direct: 'Direct'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Field Name'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Select field'
-data-importer.mapping.item.data-target.language: 'Language'
-data-importer.mapping.item.data-target.language-placeholder: 'Select language'
-data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Write If Target Is Not Empty'
-data-importer.mapping.item.data-target.write-if-source-is-empty: 'Write If Source Is Empty'
+data-importer.mapping.sources.title: Sources with preview
+data-importer.mapping.sources.reset-view: Reset view
+data-importer.mapping.sources.empty: No preview data available. Please configure a data source and run a preview import first.
+data-importer.mapping.item.new-label: New Mapping
+data-importer.mapping.item.label: Label
+data-importer.mapping.item.advanced: Advanced
+data-importer.mapping.item.delete: Delete mapping
+data-importer.mapping.item.source: Source
+data-importer.mapping.item.source-placeholder: Select source columns
+data-importer.mapping.item.destination: Destination
+data-importer.mapping.item.destination-placeholder: Select field
+data-importer.mapping.item.requires-advanced-setup: Requires advanced setup
+data-importer.mapping.item.data-source-index: Data Source Index
+data-importer.mapping.item.data-source-index-placeholder: Select source columns
+data-importer.mapping.item.transformation-pipeline.title: Transformation Pipeline
+data-importer.mapping.item.transformation-pipeline.empty: No transformation pipeline configured
+data-importer.mapping.item.transformation-result.title: Transformation Result
+data-importer.mapping.item.transformation-result.type: Result Type
+data-importer.mapping.item.data-target.title: Data Target
+data-importer.mapping.item.data-target.type: Target Type
+data-importer.mapping.item.data-target.type-placeholder: Select target type
+data-importer.mapping.item.data-target.type.direct: Direct
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Field Name
+data-importer.mapping.item.data-target.field-name-placeholder: Select field
+data-importer.mapping.item.data-target.language: Language
+data-importer.mapping.item.data-target.language-placeholder: Select language
+data-importer.mapping.item.data-target.write-if-target-is-not-empty: Write If Target Is Not Empty
+data-importer.mapping.item.data-target.write-if-source-is-empty: Write If Source Is Empty
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Mapping edit & transformations'
-data-importer.mapping.advanced-modal.save: 'Save'
-data-importer.mapping.advanced-modal.step-source: 'Source'
-data-importer.mapping.advanced-modal.step-transformations: 'Transformations'
-data-importer.mapping.advanced-modal.step-target: 'Data Target'
-data-importer.mapping.advanced-modal.no-transformers: 'No transformers configured. Add one below.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Add transformation'
-data-importer.mapping.advanced-modal.result-type: 'Result type'
-data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Write if target is not empty'
-data-importer.mapping.advanced-modal.write-if-source-empty: 'Write if source is empty'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Move up'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Move down'
-data-importer.mapping.advanced-modal.transformer.remove: 'Remove'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Edit source attributes'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Data manipulation'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Data types'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Load / Import'
-data-importer.mapping.advanced-modal.next-step: 'Next step'
-data-importer.mapping.advanced-modal.previous-step: 'Previous step'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Recalculate transformation result type'
-data-importer.mapping.advanced-modal.step-source.label: 'Source Attribute(s)'
-data-importer.mapping.advanced-modal.step-source.description: 'Choose from the list or add a new source'
-data-importer.mapping.advanced-modal.step-source.import-preview: 'Import Preview'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Search'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Name'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Data'
-data-importer.mapping.advanced-modal.loading: 'Loading…'
-data-importer.mapping.advanced-modal.no-data: 'No data'
-data-importer.mapping.advanced-modal.no-preview: 'No preview available'
-data-importer.mapping.advanced-modal.step-target.type: 'Type'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Field name'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Overwrite'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Preview Result'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Previous step'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Confirm mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Write to this field even if the target field already contains a value'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Write to this field even if the source data is empty'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Overwrite Mode'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Replace'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Merge'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'No key selected'
+data-importer.mapping.advanced-modal.title: Mapping edit & transformations
+data-importer.mapping.advanced-modal.save: Save
+data-importer.mapping.advanced-modal.step-source: Source
+data-importer.mapping.advanced-modal.step-transformations: Transformations
+data-importer.mapping.advanced-modal.step-target: Data Target
+data-importer.mapping.advanced-modal.no-transformers: No transformers configured. Add one below.
+data-importer.mapping.advanced-modal.add-transformation: + Add transformation
+data-importer.mapping.advanced-modal.result-type: Result type
+data-importer.mapping.advanced-modal.write-if-target-not-empty: Write if target is not empty
+data-importer.mapping.advanced-modal.write-if-source-empty: Write if source is empty
+data-importer.mapping.advanced-modal.transformer.move-up: Move up
+data-importer.mapping.advanced-modal.transformer.move-down: Move down
+data-importer.mapping.advanced-modal.transformer.remove: Remove
+data-importer.mapping.advanced-modal.transformer.edit-source: Edit source attributes
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Data manipulation
+data-importer.mapping.advanced-modal.transformer.group.data-types: Data types
+data-importer.mapping.advanced-modal.transformer.group.load-import: Load / Import
+data-importer.mapping.advanced-modal.next-step: Next step
+data-importer.mapping.advanced-modal.previous-step: Previous step
+data-importer.mapping.advanced-modal.recalculate-result-type: Recalculate transformation result type
+data-importer.mapping.advanced-modal.step-source.label: Source Attribute(s)
+data-importer.mapping.advanced-modal.step-source.description: Choose from the list or add a new source
+data-importer.mapping.advanced-modal.step-source.import-preview: Import Preview
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Search
+data-importer.mapping.advanced-modal.step-source.column-name: Name
+data-importer.mapping.advanced-modal.step-source.column-data: Data
+data-importer.mapping.advanced-modal.loading: Loading…
+data-importer.mapping.advanced-modal.no-data: No data
+data-importer.mapping.advanced-modal.no-preview: No preview available
+data-importer.mapping.advanced-modal.step-target.type: Type
+data-importer.mapping.advanced-modal.step-target.field-name: Field name
+data-importer.mapping.advanced-modal.step-target.overwrite: Overwrite
+data-importer.mapping.advanced-modal.step-target.preview-result: Preview Result
+data-importer.mapping.advanced-modal.step-target.previous-step: Previous step
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Confirm mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Write to this field even if the target field already contains a value
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Write to this field even if the source data is empty
+data-importer.mapping.advanced-modal.step-target.overwrite-mode: Overwrite Mode
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Replace
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Merge
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: No key selected
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} in group {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Select Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Search and select a key for this classification store field'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Select Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Search and select a key for this classification store field
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch requires transformation result type: array, quantityValueArray, inputQuantityValueArray, or dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation requires transformation result type: advancedDataObject, dataObjectArray, assetArray, or advancedAssetArray.'
 
-error.error_environment: 'Preview file is not valid for the configured interpreter. Please re-upload or re-copy the preview data.'
+error.error_environment: Preview file is not valid for the configured interpreter. Please re-upload or re-copy the preview data.
 
 # Execution Tab
-data-importer.execution.settings.title: 'Execution Settings'
-data-importer.execution.schedule-type: 'Schedule Type'
-data-importer.execution.schedule-type.recurring: 'Recurring / Cron'
-data-importer.execution.schedule-type.job: 'One-time Job'
-data-importer.execution.cron-definition: 'Cron Definition'
-data-importer.execution.cron-generator: 'Cron Generator'
-data-importer.execution.scheduled-at: 'Scheduled At'
-data-importer.execution.manual-execution: 'Manual Execution'
-data-importer.execution.start-import: 'Start Import'
-data-importer.execution.start-import.success: 'Import started successfully'
-data-importer.execution.start-import.error: 'Failed to start import'
-data-importer.execution.start-import.tooltip-dirty: 'Save your changes before starting the import'
-data-importer.execution.start-import.tooltip-push: 'Push loader does not support manual execution'
-data-importer.execution.cancel.success: 'Import cancelled'
-data-importer.execution.cancel.error: 'Failed to cancel import'
-data-importer.execution.status.title: 'Execution Status'
-data-importer.execution.status.not-running: 'Not running'
-data-importer.execution.status.finished: 'All items processed. No import running.'
-data-importer.execution.status.current-progress: 'Current Progress'
+data-importer.execution.settings.title: Execution Settings
+data-importer.execution.schedule-type: Schedule Type
+data-importer.execution.schedule-type.recurring: Recurring / Cron
+data-importer.execution.schedule-type.job: One-time Job
+data-importer.execution.cron-definition: Cron Definition
+data-importer.execution.cron-generator: Cron Generator
+data-importer.execution.scheduled-at: Scheduled At
+data-importer.execution.manual-execution: Manual Execution
+data-importer.execution.start-import: Start Import
+data-importer.execution.start-import.success: Import started successfully
+data-importer.execution.start-import.error: Failed to start import
+data-importer.execution.start-import.tooltip-dirty: Save your changes before starting the import
+data-importer.execution.start-import.tooltip-push: Push loader does not support manual execution
+data-importer.execution.cancel.success: Import cancelled
+data-importer.execution.cancel.error: Failed to cancel import
+data-importer.execution.status.title: Execution Status
+data-importer.execution.status.not-running: Not running
+data-importer.execution.status.finished: All items processed. No import running.
+data-importer.execution.status.current-progress: Current Progress
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} items processed...'
-data-importer.execution.status.cancel: 'Cancel execution & clean up queue'
-data-importer.execution.cron-validating: 'Validating cron expression...'
+data-importer.execution.status.cancel: Cancel execution & clean up queue
+data-importer.execution.cron-validating: Validating cron expression...
 data-importer.validation.required: '{{field}} is required'

--- a/src/Resources/translations/studio.es.yaml
+++ b/src/Resources/translations/studio.es.yaml
@@ -1,316 +1,316 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'General'
-data-importer.tabs.permissions: 'Permisos'
-data-importer.tabs.data-setup: 'Configuración de datos'
-data-importer.tabs.import-logs: 'Registros de importación'
-data-importer.tabs.execution: 'Ejecución'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: General
+data-importer.tabs.permissions: Permisos
+data-importer.tabs.data-setup: Configuración de datos
+data-importer.tabs.import-logs: Registros de importación
+data-importer.tabs.execution: Ejecución
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Fuente de datos'
-data-importer.data-setup.steps.data-source.description: 'Configurar fuente de datos y formato de archivo'
-data-importer.data-setup.steps.preview-import.title: 'Vista previa de importación'
-data-importer.data-setup.steps.preview-import.description: 'Vista previa de los datos a importar'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Configurar reglas de resolución de datos'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Asignar campos de origen a campos de destino'
-data-importer.data-setup.steps.processing-settings.title: 'Configuración de procesamiento'
-data-importer.data-setup.steps.processing-settings.description: 'Configurar ajustes de procesamiento de importación'
+data-importer.data-setup.steps.data-source.title: Fuente de datos
+data-importer.data-setup.steps.data-source.description: Configurar fuente de datos y formato de archivo
+data-importer.data-setup.steps.preview-import.title: Vista previa de importación
+data-importer.data-setup.steps.preview-import.description: Vista previa de los datos a importar
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Configurar reglas de resolución de datos
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Asignar campos de origen a campos de destino
+data-importer.data-setup.steps.processing-settings.title: Configuración de procesamiento
+data-importer.data-setup.steps.processing-settings.description: Configurar ajustes de procesamiento de importación
 
 # Data Source
-data-importer.data-source.title: 'Fuente de datos'
-data-importer.data-source.type: 'Tipo'
-data-importer.data-source.type-label: 'Tipo de fuente de datos'
+data-importer.data-source.title: Fuente de datos
+data-importer.data-source.type: Tipo
+data-importer.data-source.type-label: Tipo de fuente de datos
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
-data-importer.loader.asset.asset-path: 'Ruta del Asset'
+data-importer.loader.asset.asset-path: Ruta del Asset
 
 # Upload Loader
-data-importer.loader.upload.status: 'Estado de Upload'
-data-importer.loader.upload.file-uploaded: 'Archivo subido correctamente'
-data-importer.loader.upload.no-file: 'Aún no se ha subido ningún archivo'
-data-importer.loader.upload.file-path: 'Ruta del archivo subido'
-data-importer.loader.upload.open-upload: 'Subir archivo'
-data-importer.loader.upload.modal-title: 'Subir archivo de importación'
+data-importer.loader.upload.status: Estado de Upload
+data-importer.loader.upload.file-uploaded: Archivo subido correctamente
+data-importer.loader.upload.no-file: Aún no se ha subido ningún archivo
+data-importer.loader.upload.file-path: Ruta del archivo subido
+data-importer.loader.upload.open-upload: Subir archivo
+data-importer.loader.upload.modal-title: Subir archivo de importación
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Host'
-data-importer.loader.sftp.port: 'Puerto'
-data-importer.loader.sftp.username: 'Nombre de usuario'
-data-importer.loader.sftp.password: 'Contraseña'
-data-importer.loader.sftp.remote-path: 'Ruta remota'
+data-importer.loader.sftp.host: Host
+data-importer.loader.sftp.port: Puerto
+data-importer.loader.sftp.username: Nombre de usuario
+data-importer.loader.sftp.password: Contraseña
+data-importer.loader.sftp.remote-path: Ruta remota
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Generar API Key'
-data-importer.loader.push.api-key-required: 'Por favor, introduzca una API Key'
-data-importer.loader.push.api-key-min-length: 'La API Key debe tener al menos 16 caracteres'
-data-importer.loader.push.ignore-not-empty-queue: 'Ignorar cola no vacía'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Generar API Key
+data-importer.loader.push.api-key-required: Por favor, introduzca una API Key
+data-importer.loader.push.api-key-min-length: La API Key debe tener al menos 16 caracteres
+data-importer.loader.push.ignore-not-empty-queue: Ignorar cola no vacía
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Conexión de base de datos'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Conexión de base de datos
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'Formato de archivo'
-data-importer.file-format.type: 'Tipo'
+data-importer.file-format.title: Formato de archivo
+data-importer.file-format.type: Tipo
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Delimitador'
-data-importer.interpreter.csv.enclosure: 'Carácter de cierre'
-data-importer.interpreter.csv.escape: 'Carácter de escape'
+data-importer.interpreter.csv.delimiter: Delimitador
+data-importer.interpreter.csv.enclosure: Carácter de cierre
+data-importer.interpreter.csv.escape: Carácter de escape
 data-importer.interpreter.csv.required: '{{field}} es obligatorio'
 data-importer.interpreter.csv.single-char-only: '{{field}} debe estar vacío o ser un solo carácter'
-data-importer.interpreter.csv.skip-first-row: 'Omitir primera fila'
-data-importer.interpreter.csv.save-header-name: 'Guardar nombre de encabezado'
+data-importer.interpreter.csv.skip-first-row: Omitir primera fila
+data-importer.interpreter.csv.save-header-name: Guardar nombre de encabezado
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Ruta'
+data-importer.interpreter.json.path: Ruta
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Nombre de hoja'
-data-importer.interpreter.xlsx.skip-first-row: 'Omitir primera fila'
+data-importer.interpreter.xlsx.sheet-name: Nombre de hoja
+data-importer.interpreter.xlsx.skip-first-row: Omitir primera fila
 
 # SQL Interpreter
-data-importer.interpreter.sql.info: 'El intérprete SQL utiliza la configuración de consulta del cargador SQL.'
+data-importer.interpreter.sql.info: El intérprete SQL utiliza la configuración de consulta del cargador SQL.
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Clase de Data Object'
-data-importer.resolver.class-placeholder: 'Seleccionar clase'
-data-importer.resolver.element-loading: 'Carga de elementos'
-data-importer.resolver.loading-strategy: 'Estrategia de carga'
-data-importer.resolver.loading-strategy.tooltip: 'Define cómo se buscan los elementos existentes antes de la importación. Si no se encuentra ningún elemento, se aplican las reglas de creación.'
-data-importer.resolver.loading-strategy.notLoad: 'Sin carga'
-data-importer.resolver.loading-strategy.id: 'Id'
-data-importer.resolver.loading-strategy.path: 'Ruta'
-data-importer.resolver.loading-strategy.attribute: 'Atributo'
-data-importer.resolver.loading-strategy.attribute-name: 'Nombre de atributo'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Seleccionar atributo'
-data-importer.resolver.loading-strategy.data-source-index: 'Índice de fuente de datos'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Seleccionar columna'
-data-importer.resolver.loading-strategy.language: 'Idioma'
-data-importer.resolver.loading-strategy.language-placeholder: 'Seleccionar idioma'
-data-importer.resolver.loading-strategy.include-unpublished: 'Incluir objetos no publicados'
-data-importer.resolver.element-creation: 'Creación de elementos'
-data-importer.resolver.create-location-strategy: 'Estrategia de ubicación'
-data-importer.resolver.create-location-strategy.tooltip: 'Controla dónde se colocan los elementos recién creados cuando no se ha resuelto ningún elemento existente.'
-data-importer.resolver.location-strategy.staticPath: 'Ruta estática'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Buscar o crear carpeta'
-data-importer.resolver.location-strategy.findParent: 'Buscar elemento padre'
-data-importer.resolver.location-strategy.doNotCreate: 'No crear'
-data-importer.resolver.location-strategy.noChange: 'Sin cambios'
-data-importer.resolver.location-strategy.path: 'Ruta'
-data-importer.resolver.location-strategy.path-placeholder: 'Introducir ruta'
-data-importer.resolver.location-strategy.data-source-index: 'Índice de fuente de datos'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Seleccionar columna'
-data-importer.resolver.location-strategy.fallback-path: 'Ruta de respaldo'
-data-importer.resolver.location-strategy.fallback-path.tooltip: 'Se utiliza cuando no se puede resolver una ubicación de destino dinámica a partir de los datos de origen.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Introducir ruta de respaldo'
-data-importer.resolver.location-strategy.find-strategy: 'Estrategia de búsqueda'
-data-importer.resolver.location-strategy.find-strategy.id: 'Por ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'Por ruta'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'Por atributo'
-data-importer.resolver.location-strategy.attribute-class: 'Clase'
-data-importer.resolver.location-strategy.attribute-name: 'Nombre de atributo'
-data-importer.resolver.location-strategy.attribute-language: 'Idioma'
-data-importer.resolver.location-strategy.as-variant: 'Como variante'
-data-importer.resolver.element-location-update: 'Actualización de ubicación del elemento'
-data-importer.resolver.location-update-strategy: 'Estrategia de ubicación'
-data-importer.resolver.location-update-strategy.tooltip: 'Controla si se cambia la ubicación de los elementos ya resueltos durante la importación y de qué manera.'
-data-importer.resolver.element-publishing: 'Publicación de elementos'
-data-importer.resolver.publishing-strategy: 'Estrategia de publicación'
-data-importer.resolver.publishing-strategy.tooltip: 'Define el comportamiento de publicación o despublicación de los elementos importados.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'Sin cambios / Nuevos no publicados'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'Sin cambios / Nuevos publicados'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Publicar siempre'
-data-importer.resolver.publishing-strategy.attributeBased: 'Basado en atributo'
-data-importer.resolver.publishing-strategy.data-source-index: 'Índice de fuente de datos'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Seleccionar columna'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Clase de Data Object
+data-importer.resolver.class-placeholder: Seleccionar clase
+data-importer.resolver.element-loading: Carga de elementos
+data-importer.resolver.loading-strategy: Estrategia de carga
+data-importer.resolver.loading-strategy.tooltip: Define cómo se buscan los elementos existentes antes de la importación. Si no se encuentra ningún elemento, se aplican las reglas de creación.
+data-importer.resolver.loading-strategy.notLoad: Sin carga
+data-importer.resolver.loading-strategy.id: Id
+data-importer.resolver.loading-strategy.path: Ruta
+data-importer.resolver.loading-strategy.attribute: Atributo
+data-importer.resolver.loading-strategy.attribute-name: Nombre de atributo
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Seleccionar atributo
+data-importer.resolver.loading-strategy.data-source-index: Índice de fuente de datos
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Seleccionar columna
+data-importer.resolver.loading-strategy.language: Idioma
+data-importer.resolver.loading-strategy.language-placeholder: Seleccionar idioma
+data-importer.resolver.loading-strategy.include-unpublished: Incluir objetos no publicados
+data-importer.resolver.element-creation: Creación de elementos
+data-importer.resolver.create-location-strategy: Estrategia de ubicación
+data-importer.resolver.create-location-strategy.tooltip: Controla dónde se colocan los elementos recién creados cuando no se ha resuelto ningún elemento existente.
+data-importer.resolver.location-strategy.staticPath: Ruta estática
+data-importer.resolver.location-strategy.findOrCreateFolder: Buscar o crear carpeta
+data-importer.resolver.location-strategy.findParent: Buscar elemento padre
+data-importer.resolver.location-strategy.doNotCreate: No crear
+data-importer.resolver.location-strategy.noChange: Sin cambios
+data-importer.resolver.location-strategy.path: Ruta
+data-importer.resolver.location-strategy.path-placeholder: Introducir ruta
+data-importer.resolver.location-strategy.data-source-index: Índice de fuente de datos
+data-importer.resolver.location-strategy.data-source-index-placeholder: Seleccionar columna
+data-importer.resolver.location-strategy.fallback-path: Ruta de respaldo
+data-importer.resolver.location-strategy.fallback-path.tooltip: Se utiliza cuando no se puede resolver una ubicación de destino dinámica a partir de los datos de origen.
+data-importer.resolver.location-strategy.fallback-path-placeholder: Introducir ruta de respaldo
+data-importer.resolver.location-strategy.find-strategy: Estrategia de búsqueda
+data-importer.resolver.location-strategy.find-strategy.id: Por ID
+data-importer.resolver.location-strategy.find-strategy.path: Por ruta
+data-importer.resolver.location-strategy.find-strategy.attribute: Por atributo
+data-importer.resolver.location-strategy.attribute-class: Clase
+data-importer.resolver.location-strategy.attribute-name: Nombre de atributo
+data-importer.resolver.location-strategy.attribute-language: Idioma
+data-importer.resolver.location-strategy.as-variant: Como variante
+data-importer.resolver.element-location-update: Actualización de ubicación del elemento
+data-importer.resolver.location-update-strategy: Estrategia de ubicación
+data-importer.resolver.location-update-strategy.tooltip: Controla si se cambia la ubicación de los elementos ya resueltos durante la importación y de qué manera.
+data-importer.resolver.element-publishing: Publicación de elementos
+data-importer.resolver.publishing-strategy: Estrategia de publicación
+data-importer.resolver.publishing-strategy.tooltip: Define el comportamiento de publicación o despublicación de los elementos importados.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: Sin cambios / Nuevos no publicados
+data-importer.resolver.publishing-strategy.noChangePublishNew: Sin cambios / Nuevos publicados
+data-importer.resolver.publishing-strategy.alwaysPublish: Publicar siempre
+data-importer.resolver.publishing-strategy.attributeBased: Basado en atributo
+data-importer.resolver.publishing-strategy.data-source-index: Índice de fuente de datos
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Seleccionar columna
 
 # Processing Settings
-data-importer.processing.title: 'Configuración de procesamiento'
-data-importer.processing.execution.title: 'Ejecución'
-data-importer.processing.id-delta.title: 'ID, Delta Check y limpieza'
-data-importer.processing.execution-type: 'Tipo de ejecución'
-data-importer.processing.execution-type.tooltip: 'Secuencial procesa un elemento tras otro. Paralelo procesa múltiples elementos de forma concurrente.'
-data-importer.processing.execution-type.sequential: 'Secuencial'
-data-importer.processing.execution-type.parallel: 'Paralelo'
-data-importer.processing.archive-import-file: 'Archivar archivo de importación'
-data-importer.processing.disable-versioning: 'Desactivar versionado'
-data-importer.processing.id-data-index: 'Índice de datos del campo ID'
-data-importer.processing.id-data-index.tooltip: 'Columna utilizada como identificador estable para Delta Check y limpieza. Estas opciones solo están disponibles cuando se ha establecido un índice de datos de ID.'
-data-importer.processing.id-data-index-placeholder: 'Seleccionar columna'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Limpieza'
-data-importer.processing.cleanup.do-cleanup: 'Limpiar elementos no importados'
-data-importer.processing.cleanup.strategy: 'Estrategia de limpieza'
-data-importer.processing.cleanup.strategy.tooltip: 'Determina qué sucede con los elementos existentes que no están presentes en la importación actual.'
-data-importer.processing.cleanup.strategy.delete: 'Eliminar'
-data-importer.processing.cleanup.strategy.unpublish: 'Despublicar'
-data-importer.processing.logging.title: 'Configuración de registro (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Desactivar registros de información'
-data-importer.processing.logging.info.disable-file-objects: 'Desactivar objetos de archivo de información'
-data-importer.processing.logging.error.title: 'Error'
-data-importer.processing.logging.error.disable-logs: 'Desactivar registros de errores'
-data-importer.processing.logging.error.disable-file-objects: 'Desactivar objetos de archivo de errores'
+data-importer.processing.title: Configuración de procesamiento
+data-importer.processing.execution.title: Ejecución
+data-importer.processing.id-delta.title: ID, Delta Check y limpieza
+data-importer.processing.execution-type: Tipo de ejecución
+data-importer.processing.execution-type.tooltip: Secuencial procesa un elemento tras otro. Paralelo procesa múltiples elementos de forma concurrente.
+data-importer.processing.execution-type.sequential: Secuencial
+data-importer.processing.execution-type.parallel: Paralelo
+data-importer.processing.archive-import-file: Archivar archivo de importación
+data-importer.processing.disable-versioning: Desactivar versionado
+data-importer.processing.id-data-index: Índice de datos del campo ID
+data-importer.processing.id-data-index.tooltip: Columna utilizada como identificador estable para Delta Check y limpieza. Estas opciones solo están disponibles cuando se ha establecido un índice de datos de ID.
+data-importer.processing.id-data-index-placeholder: Seleccionar columna
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Limpieza
+data-importer.processing.cleanup.do-cleanup: Limpiar elementos no importados
+data-importer.processing.cleanup.strategy: Estrategia de limpieza
+data-importer.processing.cleanup.strategy.tooltip: Determina qué sucede con los elementos existentes que no están presentes en la importación actual.
+data-importer.processing.cleanup.strategy.delete: Eliminar
+data-importer.processing.cleanup.strategy.unpublish: Despublicar
+data-importer.processing.logging.title: Configuración de registro (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Desactivar registros de información
+data-importer.processing.logging.info.disable-file-objects: Desactivar objetos de archivo de información
+data-importer.processing.logging.error.title: Error
+data-importer.processing.logging.error.disable-logs: Desactivar registros de errores
+data-importer.processing.logging.error.disable-file-objects: Desactivar objetos de archivo de errores
 
 # Preview Import
-data-importer.preview-import.title: 'Vista previa de importación'
-data-importer.preview-import.choose-preview-data: 'Elegir datos de vista previa'
-data-importer.preview-import.upload-file: 'Subir archivo'
-data-importer.preview-import.copy-from-source: 'Copiar de la fuente de datos'
-data-importer.preview-import.search-placeholder: 'Buscar por nombre, origen, destino'
-data-importer.preview-import.column.label: 'Etiqueta'
-data-importer.preview-import.column.data: 'Datos'
-data-importer.preview-import.prev: 'Registro anterior'
-data-importer.preview-import.next: 'Registro siguiente'
+data-importer.preview-import.title: Vista previa de importación
+data-importer.preview-import.choose-preview-data: Elegir datos de vista previa
+data-importer.preview-import.upload-file: Subir archivo
+data-importer.preview-import.copy-from-source: Copiar de la fuente de datos
+data-importer.preview-import.search-placeholder: Buscar por nombre, origen, destino
+data-importer.preview-import.column.label: Etiqueta
+data-importer.preview-import.column.data: Datos
+data-importer.preview-import.prev: Registro anterior
+data-importer.preview-import.next: Registro siguiente
 
 # Mapping
-data-importer.mapping.title: 'Configuración de Mapping'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'Nuevo'
-data-importer.mapping.new-modal.title: 'Nuevo Mapping'
-data-importer.mapping.new-modal.source-label: 'Columna de origen'
-data-importer.mapping.new-modal.source-required: 'Por favor, seleccione una columna de origen'
-data-importer.mapping.collapse-all: 'Contraer todo'
-data-importer.mapping.expand-all: 'Expandir todo'
-data-importer.mapping.auto-fill: 'Autocompletar'
-data-importer.mapping.empty-state: 'Comience a crear un Mapping directamente desde la columna de orígenes, o haga clic en Nuevo para crear uno manualmente.'
+data-importer.mapping.title: Configuración de Mapping
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: Nuevo
+data-importer.mapping.new-modal.title: Nuevo Mapping
+data-importer.mapping.new-modal.source-label: Columna de origen
+data-importer.mapping.new-modal.source-required: Por favor, seleccione una columna de origen
+data-importer.mapping.collapse-all: Contraer todo
+data-importer.mapping.expand-all: Expandir todo
+data-importer.mapping.auto-fill: Autocompletar
+data-importer.mapping.empty-state: Comience a crear un Mapping directamente desde la columna de orígenes, o haga clic en Nuevo para crear uno manualmente.
 data-importer.mapping.filter-empty: 'Aún no hay Mappings para "{{source}}".'
-data-importer.mapping.sources.title: 'Orígenes con vista previa'
-data-importer.mapping.sources.reset-view: 'Restablecer vista'
-data-importer.mapping.sources.empty: 'No hay datos de vista previa disponibles. Por favor, configure una fuente de datos y ejecute una vista previa de importación primero.'
-data-importer.mapping.item.new-label: 'Nuevo Mapping'
-data-importer.mapping.item.label: 'Etiqueta'
-data-importer.mapping.item.advanced: 'Avanzado'
-data-importer.mapping.item.delete: 'Eliminar Mapping'
-data-importer.mapping.item.source: 'Origen'
-data-importer.mapping.item.source-placeholder: 'Seleccionar columnas de origen'
-data-importer.mapping.item.destination: 'Destino'
-data-importer.mapping.item.destination-placeholder: 'Seleccionar campo'
-data-importer.mapping.item.requires-advanced-setup: 'Requiere configuración avanzada'
-data-importer.mapping.item.data-source-index: 'Índice de fuente de datos'
-data-importer.mapping.item.data-source-index-placeholder: 'Seleccionar columnas de origen'
-data-importer.mapping.item.transformation-pipeline.title: 'Pipeline de transformación'
-data-importer.mapping.item.transformation-pipeline.empty: 'No se ha configurado ninguna Pipeline de transformación'
-data-importer.mapping.item.transformation-result.title: 'Resultado de transformación'
-data-importer.mapping.item.transformation-result.type: 'Tipo de resultado'
-data-importer.mapping.item.data-target.title: 'Destino de datos'
-data-importer.mapping.item.data-target.type: 'Tipo de destino'
-data-importer.mapping.item.data-target.type-placeholder: 'Seleccionar tipo de destino'
-data-importer.mapping.item.data-target.type.direct: 'Directo'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Nombre de campo'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Seleccionar campo'
-data-importer.mapping.item.data-target.language: 'Idioma'
-data-importer.mapping.item.data-target.language-placeholder: 'Seleccionar idioma'
-data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Escribir si el destino no está vacío'
-data-importer.mapping.item.data-target.write-if-source-is-empty: 'Escribir si el origen está vacío'
+data-importer.mapping.sources.title: Orígenes con vista previa
+data-importer.mapping.sources.reset-view: Restablecer vista
+data-importer.mapping.sources.empty: No hay datos de vista previa disponibles. Por favor, configure una fuente de datos y ejecute una vista previa de importación primero.
+data-importer.mapping.item.new-label: Nuevo Mapping
+data-importer.mapping.item.label: Etiqueta
+data-importer.mapping.item.advanced: Avanzado
+data-importer.mapping.item.delete: Eliminar Mapping
+data-importer.mapping.item.source: Origen
+data-importer.mapping.item.source-placeholder: Seleccionar columnas de origen
+data-importer.mapping.item.destination: Destino
+data-importer.mapping.item.destination-placeholder: Seleccionar campo
+data-importer.mapping.item.requires-advanced-setup: Requiere configuración avanzada
+data-importer.mapping.item.data-source-index: Índice de fuente de datos
+data-importer.mapping.item.data-source-index-placeholder: Seleccionar columnas de origen
+data-importer.mapping.item.transformation-pipeline.title: Pipeline de transformación
+data-importer.mapping.item.transformation-pipeline.empty: No se ha configurado ninguna Pipeline de transformación
+data-importer.mapping.item.transformation-result.title: Resultado de transformación
+data-importer.mapping.item.transformation-result.type: Tipo de resultado
+data-importer.mapping.item.data-target.title: Destino de datos
+data-importer.mapping.item.data-target.type: Tipo de destino
+data-importer.mapping.item.data-target.type-placeholder: Seleccionar tipo de destino
+data-importer.mapping.item.data-target.type.direct: Directo
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Nombre de campo
+data-importer.mapping.item.data-target.field-name-placeholder: Seleccionar campo
+data-importer.mapping.item.data-target.language: Idioma
+data-importer.mapping.item.data-target.language-placeholder: Seleccionar idioma
+data-importer.mapping.item.data-target.write-if-target-is-not-empty: Escribir si el destino no está vacío
+data-importer.mapping.item.data-target.write-if-source-is-empty: Escribir si el origen está vacío
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Edición de Mapping y transformaciones'
-data-importer.mapping.advanced-modal.save: 'Guardar'
-data-importer.mapping.advanced-modal.step-source: 'Origen'
-data-importer.mapping.advanced-modal.step-transformations: 'Transformaciones'
-data-importer.mapping.advanced-modal.step-target: 'Destino de datos'
-data-importer.mapping.advanced-modal.no-transformers: 'No se han configurado transformadores. Añada uno a continuación.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Añadir transformación'
-data-importer.mapping.advanced-modal.result-type: 'Tipo de resultado'
-data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Escribir si el destino no está vacío'
-data-importer.mapping.advanced-modal.write-if-source-empty: 'Escribir si el origen está vacío'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Mover arriba'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Mover abajo'
-data-importer.mapping.advanced-modal.transformer.remove: 'Eliminar'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Editar atributos de origen'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Manipulación de datos'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Tipos de datos'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Cargar / Importar'
-data-importer.mapping.advanced-modal.next-step: 'Siguiente paso'
-data-importer.mapping.advanced-modal.previous-step: 'Paso anterior'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Recalcular tipo de resultado de transformación'
-data-importer.mapping.advanced-modal.step-source.label: 'Atributo(s) de origen'
-data-importer.mapping.advanced-modal.step-source.description: 'Seleccione de la lista o añada un nuevo origen'
-data-importer.mapping.advanced-modal.step-source.import-preview: 'Vista previa de importación'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Buscar'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Nombre'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Datos'
-data-importer.mapping.advanced-modal.loading: 'Cargando…'
-data-importer.mapping.advanced-modal.no-data: 'Sin datos'
-data-importer.mapping.advanced-modal.no-preview: 'Vista previa no disponible'
-data-importer.mapping.advanced-modal.step-target.type: 'Tipo'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Nombre de campo'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Sobrescribir'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Vista previa del resultado'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Paso anterior'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Confirmar Mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Escribir en este campo aunque el campo de destino ya contenga un valor'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Escribir en este campo aunque los datos de origen estén vacíos'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Modo de sobrescritura'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Reemplazar'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Fusionar'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'Ninguna clave seleccionada'
+data-importer.mapping.advanced-modal.title: Edición de Mapping y transformaciones
+data-importer.mapping.advanced-modal.save: Guardar
+data-importer.mapping.advanced-modal.step-source: Origen
+data-importer.mapping.advanced-modal.step-transformations: Transformaciones
+data-importer.mapping.advanced-modal.step-target: Destino de datos
+data-importer.mapping.advanced-modal.no-transformers: No se han configurado transformadores. Añada uno a continuación.
+data-importer.mapping.advanced-modal.add-transformation: + Añadir transformación
+data-importer.mapping.advanced-modal.result-type: Tipo de resultado
+data-importer.mapping.advanced-modal.write-if-target-not-empty: Escribir si el destino no está vacío
+data-importer.mapping.advanced-modal.write-if-source-empty: Escribir si el origen está vacío
+data-importer.mapping.advanced-modal.transformer.move-up: Mover arriba
+data-importer.mapping.advanced-modal.transformer.move-down: Mover abajo
+data-importer.mapping.advanced-modal.transformer.remove: Eliminar
+data-importer.mapping.advanced-modal.transformer.edit-source: Editar atributos de origen
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Manipulación de datos
+data-importer.mapping.advanced-modal.transformer.group.data-types: Tipos de datos
+data-importer.mapping.advanced-modal.transformer.group.load-import: Cargar / Importar
+data-importer.mapping.advanced-modal.next-step: Siguiente paso
+data-importer.mapping.advanced-modal.previous-step: Paso anterior
+data-importer.mapping.advanced-modal.recalculate-result-type: Recalcular tipo de resultado de transformación
+data-importer.mapping.advanced-modal.step-source.label: Atributo(s) de origen
+data-importer.mapping.advanced-modal.step-source.description: Seleccione de la lista o añada un nuevo origen
+data-importer.mapping.advanced-modal.step-source.import-preview: Vista previa de importación
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Buscar
+data-importer.mapping.advanced-modal.step-source.column-name: Nombre
+data-importer.mapping.advanced-modal.step-source.column-data: Datos
+data-importer.mapping.advanced-modal.loading: Cargando…
+data-importer.mapping.advanced-modal.no-data: Sin datos
+data-importer.mapping.advanced-modal.no-preview: Vista previa no disponible
+data-importer.mapping.advanced-modal.step-target.type: Tipo
+data-importer.mapping.advanced-modal.step-target.field-name: Nombre de campo
+data-importer.mapping.advanced-modal.step-target.overwrite: Sobrescribir
+data-importer.mapping.advanced-modal.step-target.preview-result: Vista previa del resultado
+data-importer.mapping.advanced-modal.step-target.previous-step: Paso anterior
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Confirmar Mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Escribir en este campo aunque el campo de destino ya contenga un valor
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Escribir en este campo aunque los datos de origen estén vacíos
+data-importer.mapping.advanced-modal.step-target.overwrite-mode: Modo de sobrescritura
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Reemplazar
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Fusionar
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: Ninguna clave seleccionada
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} en grupo {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Seleccionar Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Busque y seleccione una clave para este campo de Classification Store'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Seleccionar Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Busque y seleccione una clave para este campo de Classification Store
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch requiere el tipo de resultado de transformación: array, quantityValueArray, inputQuantityValueArray o dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation requiere el tipo de resultado de transformación: advancedDataObject, dataObjectArray, assetArray o advancedAssetArray.'
 
-error.error_environment: 'El archivo de vista previa no es válido para el intérprete configurado. Por favor, vuelva a subir o copiar los datos de vista previa.'
+error.error_environment: El archivo de vista previa no es válido para el intérprete configurado. Por favor, vuelva a subir o copiar los datos de vista previa.
 
 # Execution Tab
-data-importer.execution.settings.title: 'Configuración de ejecución'
-data-importer.execution.schedule-type: 'Tipo de programación'
-data-importer.execution.schedule-type.recurring: 'Recurrente / Cron'
-data-importer.execution.schedule-type.job: 'Tarea única'
-data-importer.execution.cron-definition: 'Definición de Cron'
-data-importer.execution.cron-generator: 'Generador de Cron'
-data-importer.execution.scheduled-at: 'Programado para'
-data-importer.execution.manual-execution: 'Ejecución manual'
-data-importer.execution.start-import: 'Iniciar importación'
-data-importer.execution.start-import.success: 'Importación iniciada correctamente'
-data-importer.execution.start-import.error: 'No se pudo iniciar la importación'
-data-importer.execution.start-import.tooltip-dirty: 'Guarde sus cambios antes de iniciar la importación'
-data-importer.execution.start-import.tooltip-push: 'El cargador Push no admite ejecución manual'
-data-importer.execution.cancel.success: 'Importación cancelada'
-data-importer.execution.cancel.error: 'No se pudo cancelar la importación'
-data-importer.execution.status.title: 'Estado de ejecución'
-data-importer.execution.status.not-running: 'No está en ejecución'
-data-importer.execution.status.finished: 'Todos los elementos procesados. No hay importación en curso.'
-data-importer.execution.status.current-progress: 'Progreso actual'
+data-importer.execution.settings.title: Configuración de ejecución
+data-importer.execution.schedule-type: Tipo de programación
+data-importer.execution.schedule-type.recurring: Recurrente / Cron
+data-importer.execution.schedule-type.job: Tarea única
+data-importer.execution.cron-definition: Definición de Cron
+data-importer.execution.cron-generator: Generador de Cron
+data-importer.execution.scheduled-at: Programado para
+data-importer.execution.manual-execution: Ejecución manual
+data-importer.execution.start-import: Iniciar importación
+data-importer.execution.start-import.success: Importación iniciada correctamente
+data-importer.execution.start-import.error: No se pudo iniciar la importación
+data-importer.execution.start-import.tooltip-dirty: Guarde sus cambios antes de iniciar la importación
+data-importer.execution.start-import.tooltip-push: El cargador Push no admite ejecución manual
+data-importer.execution.cancel.success: Importación cancelada
+data-importer.execution.cancel.error: No se pudo cancelar la importación
+data-importer.execution.status.title: Estado de ejecución
+data-importer.execution.status.not-running: No está en ejecución
+data-importer.execution.status.finished: Todos los elementos procesados. No hay importación en curso.
+data-importer.execution.status.current-progress: Progreso actual
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} elementos procesados...'
-data-importer.execution.status.cancel: 'Cancelar ejecución y limpiar cola'
-data-importer.execution.cron-validating: 'Validando expresión Cron...'
+data-importer.execution.status.cancel: Cancelar ejecución y limpiar cola
+data-importer.execution.cron-validating: Validando expresión Cron...
 data-importer.validation.required: '{{field}} es obligatorio'

--- a/src/Resources/translations/studio.fr.yaml
+++ b/src/Resources/translations/studio.fr.yaml
@@ -1,290 +1,290 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'Général'
-data-importer.tabs.permissions: 'Permissions'
-data-importer.tabs.data-setup: 'Configuration des données'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: Général
+data-importer.tabs.permissions: Permissions
+data-importer.tabs.data-setup: Configuration des données
 data-importer.tabs.import-logs: 'Journaux d''import'
-data-importer.tabs.execution: 'Exécution'
+data-importer.tabs.execution: Exécution
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Source de données'
-data-importer.data-setup.steps.data-source.description: 'Configurer la source de données et le format de fichier'
+data-importer.data-setup.steps.data-source.title: Source de données
+data-importer.data-setup.steps.data-source.description: Configurer la source de données et le format de fichier
 data-importer.data-setup.steps.preview-import.title: 'Aperçu de l''import'
-data-importer.data-setup.steps.preview-import.description: 'Prévisualiser les données à importer'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Configurer les règles de résolution des données'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Associer les champs source aux champs cible'
-data-importer.data-setup.steps.processing-settings.title: 'Paramètres de traitement'
+data-importer.data-setup.steps.preview-import.description: Prévisualiser les données à importer
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Configurer les règles de résolution des données
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Associer les champs source aux champs cible
+data-importer.data-setup.steps.processing-settings.title: Paramètres de traitement
 data-importer.data-setup.steps.processing-settings.description: 'Configurer les paramètres de traitement de l''import'
 
 # Data Source
-data-importer.data-source.title: 'Source de données'
-data-importer.data-source.type: 'Type'
-data-importer.data-source.type-label: 'Type de source de données'
+data-importer.data-source.title: Source de données
+data-importer.data-source.type: Type
+data-importer.data-source.type-label: Type de source de données
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
 data-importer.loader.asset.asset-path: 'Chemin de l''Asset'
 
 # Upload Loader
 data-importer.loader.upload.status: 'Statut de l''Upload'
-data-importer.loader.upload.file-uploaded: 'Fichier téléversé avec succès'
-data-importer.loader.upload.no-file: 'Aucun fichier téléversé'
-data-importer.loader.upload.file-path: 'Chemin du fichier téléversé'
-data-importer.loader.upload.open-upload: 'Téléverser un fichier'
+data-importer.loader.upload.file-uploaded: Fichier téléversé avec succès
+data-importer.loader.upload.no-file: Aucun fichier téléversé
+data-importer.loader.upload.file-path: Chemin du fichier téléversé
+data-importer.loader.upload.open-upload: Téléverser un fichier
 data-importer.loader.upload.modal-title: 'Téléverser un fichier d''import'
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Hôte'
-data-importer.loader.sftp.port: 'Port'
+data-importer.loader.sftp.host: Hôte
+data-importer.loader.sftp.port: Port
 data-importer.loader.sftp.username: 'Nom d''utilisateur'
-data-importer.loader.sftp.password: 'Mot de passe'
-data-importer.loader.sftp.remote-path: 'Chemin distant'
+data-importer.loader.sftp.password: Mot de passe
+data-importer.loader.sftp.remote-path: Chemin distant
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Générer une API Key'
-data-importer.loader.push.api-key-required: 'Veuillez saisir une API Key'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Générer une API Key
+data-importer.loader.push.api-key-required: Veuillez saisir une API Key
 data-importer.loader.push.api-key-min-length: 'L''API Key doit comporter au moins 16 caractères'
 data-importer.loader.push.ignore-not-empty-queue: 'Ignorer la file d''attente non vide'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Connexion à la base de données'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Connexion à la base de données
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'Format de fichier'
-data-importer.file-format.type: 'Type'
+data-importer.file-format.title: Format de fichier
+data-importer.file-format.type: Type
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Délimiteur'
+data-importer.interpreter.csv.delimiter: Délimiteur
 data-importer.interpreter.csv.enclosure: 'Caractère d''encadrement'
 data-importer.interpreter.csv.escape: 'Caractère d''échappement'
 data-importer.interpreter.csv.required: '{{field}} est requis'
 data-importer.interpreter.csv.single-char-only: '{{field}} doit être vide ou un seul caractère'
-data-importer.interpreter.csv.skip-first-row: 'Ignorer la première ligne'
+data-importer.interpreter.csv.skip-first-row: Ignorer la première ligne
 data-importer.interpreter.csv.save-header-name: 'Enregistrer le nom d''en-tête'
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Chemin'
+data-importer.interpreter.json.path: Chemin
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Nom de la feuille'
-data-importer.interpreter.xlsx.skip-first-row: 'Ignorer la première ligne'
+data-importer.interpreter.xlsx.sheet-name: Nom de la feuille
+data-importer.interpreter.xlsx.skip-first-row: Ignorer la première ligne
 
 # SQL Interpreter
 data-importer.interpreter.sql.info: 'L''interpréteur SQL utilise la configuration de requête du chargeur SQL.'
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Classe Data Object'
-data-importer.resolver.class-placeholder: 'Sélectionner une classe'
-data-importer.resolver.element-loading: 'Chargement des éléments'
-data-importer.resolver.loading-strategy: 'Stratégie de chargement'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Classe Data Object
+data-importer.resolver.class-placeholder: Sélectionner une classe
+data-importer.resolver.element-loading: Chargement des éléments
+data-importer.resolver.loading-strategy: Stratégie de chargement
 data-importer.resolver.loading-strategy.tooltip: 'Définit comment les éléments existants sont identifiés avant l''import. Si aucun élément n''est trouvé, les règles de création sont appliquées.'
-data-importer.resolver.loading-strategy.notLoad: 'Pas de chargement'
-data-importer.resolver.loading-strategy.id: 'Id'
-data-importer.resolver.loading-strategy.path: 'Chemin'
-data-importer.resolver.loading-strategy.attribute: 'Attribut'
+data-importer.resolver.loading-strategy.notLoad: Pas de chargement
+data-importer.resolver.loading-strategy.id: Id
+data-importer.resolver.loading-strategy.path: Chemin
+data-importer.resolver.loading-strategy.attribute: Attribut
 data-importer.resolver.loading-strategy.attribute-name: 'Nom de l''attribut'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Sélectionner un attribut'
-data-importer.resolver.loading-strategy.data-source-index: 'Index de la source de données'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Sélectionner une colonne'
-data-importer.resolver.loading-strategy.language: 'Langue'
-data-importer.resolver.loading-strategy.language-placeholder: 'Sélectionner une langue'
-data-importer.resolver.loading-strategy.include-unpublished: 'Inclure les objets non publiés'
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Sélectionner un attribut
+data-importer.resolver.loading-strategy.data-source-index: Index de la source de données
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Sélectionner une colonne
+data-importer.resolver.loading-strategy.language: Langue
+data-importer.resolver.loading-strategy.language-placeholder: Sélectionner une langue
+data-importer.resolver.loading-strategy.include-unpublished: Inclure les objets non publiés
 data-importer.resolver.element-creation: 'Création d''éléments'
-data-importer.resolver.create-location-strategy: 'Stratégie de localisation'
+data-importer.resolver.create-location-strategy: Stratégie de localisation
 data-importer.resolver.create-location-strategy.tooltip: 'Contrôle l''emplacement des éléments nouvellement créés lorsqu''aucun élément existant n''a été résolu.'
-data-importer.resolver.location-strategy.staticPath: 'Chemin statique'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Trouver ou créer un dossier'
-data-importer.resolver.location-strategy.findParent: 'Trouver le parent'
-data-importer.resolver.location-strategy.doNotCreate: 'Ne pas créer'
-data-importer.resolver.location-strategy.noChange: 'Aucune modification'
-data-importer.resolver.location-strategy.path: 'Chemin'
-data-importer.resolver.location-strategy.path-placeholder: 'Saisir un chemin'
-data-importer.resolver.location-strategy.data-source-index: 'Index de la source de données'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Sélectionner une colonne'
-data-importer.resolver.location-strategy.fallback-path: 'Chemin de repli'
+data-importer.resolver.location-strategy.staticPath: Chemin statique
+data-importer.resolver.location-strategy.findOrCreateFolder: Trouver ou créer un dossier
+data-importer.resolver.location-strategy.findParent: Trouver le parent
+data-importer.resolver.location-strategy.doNotCreate: Ne pas créer
+data-importer.resolver.location-strategy.noChange: Aucune modification
+data-importer.resolver.location-strategy.path: Chemin
+data-importer.resolver.location-strategy.path-placeholder: Saisir un chemin
+data-importer.resolver.location-strategy.data-source-index: Index de la source de données
+data-importer.resolver.location-strategy.data-source-index-placeholder: Sélectionner une colonne
+data-importer.resolver.location-strategy.fallback-path: Chemin de repli
 data-importer.resolver.location-strategy.fallback-path.tooltip: 'Utilisé lorsqu''un emplacement cible dynamique ne peut pas être résolu à partir des données source.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Saisir un chemin de repli'
-data-importer.resolver.location-strategy.find-strategy: 'Stratégie de recherche'
-data-importer.resolver.location-strategy.find-strategy.id: 'Par ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'Par chemin'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'Par attribut'
-data-importer.resolver.location-strategy.attribute-class: 'Classe'
+data-importer.resolver.location-strategy.fallback-path-placeholder: Saisir un chemin de repli
+data-importer.resolver.location-strategy.find-strategy: Stratégie de recherche
+data-importer.resolver.location-strategy.find-strategy.id: Par ID
+data-importer.resolver.location-strategy.find-strategy.path: Par chemin
+data-importer.resolver.location-strategy.find-strategy.attribute: Par attribut
+data-importer.resolver.location-strategy.attribute-class: Classe
 data-importer.resolver.location-strategy.attribute-name: 'Nom de l''attribut'
-data-importer.resolver.location-strategy.attribute-language: 'Langue'
-data-importer.resolver.location-strategy.as-variant: 'En tant que variante'
+data-importer.resolver.location-strategy.attribute-language: Langue
+data-importer.resolver.location-strategy.as-variant: En tant que variante
 data-importer.resolver.element-location-update: 'Mise à jour de l''emplacement des éléments'
-data-importer.resolver.location-update-strategy: 'Stratégie de localisation'
+data-importer.resolver.location-update-strategy: Stratégie de localisation
 data-importer.resolver.location-update-strategy.tooltip: 'Contrôle si et comment l''emplacement des éléments déjà résolus est modifié lors de l''import.'
-data-importer.resolver.element-publishing: 'Publication des éléments'
-data-importer.resolver.publishing-strategy: 'Stratégie de publication'
-data-importer.resolver.publishing-strategy.tooltip: 'Définit le comportement de publication ou de dépublication pour les éléments importés.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'Aucune modification / Dépublier les nouveaux'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'Aucune modification / Publier les nouveaux'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Toujours publier'
-data-importer.resolver.publishing-strategy.attributeBased: 'Basé sur un attribut'
-data-importer.resolver.publishing-strategy.data-source-index: 'Index de la source de données'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Sélectionner une colonne'
+data-importer.resolver.element-publishing: Publication des éléments
+data-importer.resolver.publishing-strategy: Stratégie de publication
+data-importer.resolver.publishing-strategy.tooltip: Définit le comportement de publication ou de dépublication pour les éléments importés.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: Aucune modification / Dépublier les nouveaux
+data-importer.resolver.publishing-strategy.noChangePublishNew: Aucune modification / Publier les nouveaux
+data-importer.resolver.publishing-strategy.alwaysPublish: Toujours publier
+data-importer.resolver.publishing-strategy.attributeBased: Basé sur un attribut
+data-importer.resolver.publishing-strategy.data-source-index: Index de la source de données
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Sélectionner une colonne
 
 # Processing Settings
-data-importer.processing.title: 'Paramètres de traitement'
-data-importer.processing.execution.title: 'Exécution'
-data-importer.processing.id-delta.title: 'ID, Delta Check & Nettoyage'
+data-importer.processing.title: Paramètres de traitement
+data-importer.processing.execution.title: Exécution
+data-importer.processing.id-delta.title: ID, Delta Check & Nettoyage
 data-importer.processing.execution-type: 'Type d''exécution'
 data-importer.processing.execution-type.tooltip: 'Séquentiel traite un élément après l''autre. Parallèle traite plusieurs éléments simultanément.'
-data-importer.processing.execution-type.sequential: 'Séquentiel'
-data-importer.processing.execution-type.parallel: 'Parallèle'
+data-importer.processing.execution-type.sequential: Séquentiel
+data-importer.processing.execution-type.parallel: Parallèle
 data-importer.processing.archive-import-file: 'Archiver le fichier d''import'
-data-importer.processing.disable-versioning: 'Désactiver le versionnement'
-data-importer.processing.id-data-index: 'Index de données du champ ID'
+data-importer.processing.disable-versioning: Désactiver le versionnement
+data-importer.processing.id-data-index: Index de données du champ ID
 data-importer.processing.id-data-index.tooltip: 'Colonne utilisée comme identifiant stable pour le Delta Check et le nettoyage. Ces options ne sont disponibles que lorsqu''un index de données ID est défini.'
-data-importer.processing.id-data-index-placeholder: 'Sélectionner une colonne'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Nettoyage'
-data-importer.processing.cleanup.do-cleanup: 'Nettoyer les éléments non importés'
-data-importer.processing.cleanup.strategy: 'Stratégie de nettoyage'
+data-importer.processing.id-data-index-placeholder: Sélectionner une colonne
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Nettoyage
+data-importer.processing.cleanup.do-cleanup: Nettoyer les éléments non importés
+data-importer.processing.cleanup.strategy: Stratégie de nettoyage
 data-importer.processing.cleanup.strategy.tooltip: 'Détermine ce qui arrive aux éléments existants qui ne sont pas présents dans l''import actuel.'
-data-importer.processing.cleanup.strategy.delete: 'Supprimer'
-data-importer.processing.cleanup.strategy.unpublish: 'Dépublier'
-data-importer.processing.logging.title: 'Paramètres de journalisation (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Désactiver les journaux Info'
-data-importer.processing.logging.info.disable-file-objects: 'Désactiver les fichiers objets Info'
-data-importer.processing.logging.error.title: 'Erreur'
+data-importer.processing.cleanup.strategy.delete: Supprimer
+data-importer.processing.cleanup.strategy.unpublish: Dépublier
+data-importer.processing.logging.title: Paramètres de journalisation (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Désactiver les journaux Info
+data-importer.processing.logging.info.disable-file-objects: Désactiver les fichiers objets Info
+data-importer.processing.logging.error.title: Erreur
 data-importer.processing.logging.error.disable-logs: 'Désactiver les journaux d''erreur'
 data-importer.processing.logging.error.disable-file-objects: 'Désactiver les fichiers objets d''erreur'
 
 # Preview Import
 data-importer.preview-import.title: 'Aperçu de l''import'
 data-importer.preview-import.choose-preview-data: 'Choisir les données d''aperçu'
-data-importer.preview-import.upload-file: 'Téléverser un fichier'
-data-importer.preview-import.copy-from-source: 'Copier depuis la source de données'
-data-importer.preview-import.search-placeholder: 'Rechercher par nom, source, destination'
-data-importer.preview-import.column.label: 'Libellé'
-data-importer.preview-import.column.data: 'Données'
-data-importer.preview-import.prev: 'Enregistrement précédent'
-data-importer.preview-import.next: 'Enregistrement suivant'
+data-importer.preview-import.upload-file: Téléverser un fichier
+data-importer.preview-import.copy-from-source: Copier depuis la source de données
+data-importer.preview-import.search-placeholder: Rechercher par nom, source, destination
+data-importer.preview-import.column.label: Libellé
+data-importer.preview-import.column.data: Données
+data-importer.preview-import.prev: Enregistrement précédent
+data-importer.preview-import.next: Enregistrement suivant
 
 # Mapping
-data-importer.mapping.title: 'Configuration du Mapping'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'Nouveau'
-data-importer.mapping.new-modal.title: 'Nouveau Mapping'
-data-importer.mapping.new-modal.source-label: 'Colonne source'
-data-importer.mapping.new-modal.source-required: 'Veuillez sélectionner une colonne source'
-data-importer.mapping.collapse-all: 'Tout réduire'
-data-importer.mapping.expand-all: 'Tout développer'
-data-importer.mapping.auto-fill: 'Remplissage automatique'
-data-importer.mapping.empty-state: 'Commencez à créer un Mapping directement depuis la colonne Sources, ou cliquez sur Nouveau pour en créer un manuellement.'
+data-importer.mapping.title: Configuration du Mapping
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: Nouveau
+data-importer.mapping.new-modal.title: Nouveau Mapping
+data-importer.mapping.new-modal.source-label: Colonne source
+data-importer.mapping.new-modal.source-required: Veuillez sélectionner une colonne source
+data-importer.mapping.collapse-all: Tout réduire
+data-importer.mapping.expand-all: Tout développer
+data-importer.mapping.auto-fill: Remplissage automatique
+data-importer.mapping.empty-state: Commencez à créer un Mapping directement depuis la colonne Sources, ou cliquez sur Nouveau pour en créer un manuellement.
 data-importer.mapping.filter-empty: 'Aucun Mapping pour « {{source}} » pour le moment.'
-data-importer.mapping.sources.title: 'Sources avec aperçu'
-data-importer.mapping.sources.reset-view: 'Réinitialiser la vue'
+data-importer.mapping.sources.title: Sources avec aperçu
+data-importer.mapping.sources.reset-view: Réinitialiser la vue
 data-importer.mapping.sources.empty: 'Aucune donnée d''aperçu disponible. Veuillez configurer une source de données et exécuter un aperçu de l''import au préalable.'
-data-importer.mapping.item.new-label: 'Nouveau Mapping'
-data-importer.mapping.item.label: 'Libellé'
-data-importer.mapping.item.advanced: 'Avancé'
-data-importer.mapping.item.delete: 'Supprimer le Mapping'
-data-importer.mapping.item.source: 'Source'
-data-importer.mapping.item.source-placeholder: 'Sélectionner les colonnes source'
-data-importer.mapping.item.destination: 'Destination'
-data-importer.mapping.item.destination-placeholder: 'Sélectionner un champ'
-data-importer.mapping.item.requires-advanced-setup: 'Nécessite une configuration avancée'
-data-importer.mapping.item.data-source-index: 'Index de la source de données'
-data-importer.mapping.item.data-source-index-placeholder: 'Sélectionner les colonnes source'
-data-importer.mapping.item.transformation-pipeline.title: 'Pipeline de transformation'
-data-importer.mapping.item.transformation-pipeline.empty: 'Aucun Pipeline de transformation configuré'
-data-importer.mapping.item.transformation-result.title: 'Résultat de la transformation'
-data-importer.mapping.item.transformation-result.type: 'Type de résultat'
-data-importer.mapping.item.data-target.title: 'Cible des données'
-data-importer.mapping.item.data-target.type: 'Type de cible'
-data-importer.mapping.item.data-target.type-placeholder: 'Sélectionner un type de cible'
-data-importer.mapping.item.data-target.type.direct: 'Direct'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Nom du champ'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Sélectionner un champ'
-data-importer.mapping.item.data-target.language: 'Langue'
-data-importer.mapping.item.data-target.language-placeholder: 'Sélectionner une langue'
+data-importer.mapping.item.new-label: Nouveau Mapping
+data-importer.mapping.item.label: Libellé
+data-importer.mapping.item.advanced: Avancé
+data-importer.mapping.item.delete: Supprimer le Mapping
+data-importer.mapping.item.source: Source
+data-importer.mapping.item.source-placeholder: Sélectionner les colonnes source
+data-importer.mapping.item.destination: Destination
+data-importer.mapping.item.destination-placeholder: Sélectionner un champ
+data-importer.mapping.item.requires-advanced-setup: Nécessite une configuration avancée
+data-importer.mapping.item.data-source-index: Index de la source de données
+data-importer.mapping.item.data-source-index-placeholder: Sélectionner les colonnes source
+data-importer.mapping.item.transformation-pipeline.title: Pipeline de transformation
+data-importer.mapping.item.transformation-pipeline.empty: Aucun Pipeline de transformation configuré
+data-importer.mapping.item.transformation-result.title: Résultat de la transformation
+data-importer.mapping.item.transformation-result.type: Type de résultat
+data-importer.mapping.item.data-target.title: Cible des données
+data-importer.mapping.item.data-target.type: Type de cible
+data-importer.mapping.item.data-target.type-placeholder: Sélectionner un type de cible
+data-importer.mapping.item.data-target.type.direct: Direct
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Nom du champ
+data-importer.mapping.item.data-target.field-name-placeholder: Sélectionner un champ
+data-importer.mapping.item.data-target.language: Langue
+data-importer.mapping.item.data-target.language-placeholder: Sélectionner une langue
 data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Écrire si la cible n''est pas vide'
-data-importer.mapping.item.data-target.write-if-source-is-empty: 'Écrire si la source est vide'
+data-importer.mapping.item.data-target.write-if-source-is-empty: Écrire si la source est vide
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Édition du Mapping & transformations'
-data-importer.mapping.advanced-modal.save: 'Enregistrer'
-data-importer.mapping.advanced-modal.step-source: 'Source'
-data-importer.mapping.advanced-modal.step-transformations: 'Transformations'
-data-importer.mapping.advanced-modal.step-target: 'Cible des données'
-data-importer.mapping.advanced-modal.no-transformers: 'Aucun transformateur configuré. Ajoutez-en un ci-dessous.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Ajouter une transformation'
-data-importer.mapping.advanced-modal.result-type: 'Type de résultat'
+data-importer.mapping.advanced-modal.title: Édition du Mapping & transformations
+data-importer.mapping.advanced-modal.save: Enregistrer
+data-importer.mapping.advanced-modal.step-source: Source
+data-importer.mapping.advanced-modal.step-transformations: Transformations
+data-importer.mapping.advanced-modal.step-target: Cible des données
+data-importer.mapping.advanced-modal.no-transformers: Aucun transformateur configuré. Ajoutez-en un ci-dessous.
+data-importer.mapping.advanced-modal.add-transformation: + Ajouter une transformation
+data-importer.mapping.advanced-modal.result-type: Type de résultat
 data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Écrire si la cible n''est pas vide'
-data-importer.mapping.advanced-modal.write-if-source-empty: 'Écrire si la source est vide'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Monter'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Descendre'
-data-importer.mapping.advanced-modal.transformer.remove: 'Supprimer'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Modifier les attributs source'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Manipulation des données'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Types de données'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Chargement / Import'
-data-importer.mapping.advanced-modal.next-step: 'Étape suivante'
-data-importer.mapping.advanced-modal.previous-step: 'Étape précédente'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Recalculer le type de résultat de la transformation'
-data-importer.mapping.advanced-modal.step-source.label: 'Attribut(s) source'
-data-importer.mapping.advanced-modal.step-source.description: 'Choisir dans la liste ou ajouter une nouvelle source'
+data-importer.mapping.advanced-modal.write-if-source-empty: Écrire si la source est vide
+data-importer.mapping.advanced-modal.transformer.move-up: Monter
+data-importer.mapping.advanced-modal.transformer.move-down: Descendre
+data-importer.mapping.advanced-modal.transformer.remove: Supprimer
+data-importer.mapping.advanced-modal.transformer.edit-source: Modifier les attributs source
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Manipulation des données
+data-importer.mapping.advanced-modal.transformer.group.data-types: Types de données
+data-importer.mapping.advanced-modal.transformer.group.load-import: Chargement / Import
+data-importer.mapping.advanced-modal.next-step: Étape suivante
+data-importer.mapping.advanced-modal.previous-step: Étape précédente
+data-importer.mapping.advanced-modal.recalculate-result-type: Recalculer le type de résultat de la transformation
+data-importer.mapping.advanced-modal.step-source.label: Attribut(s) source
+data-importer.mapping.advanced-modal.step-source.description: Choisir dans la liste ou ajouter une nouvelle source
 data-importer.mapping.advanced-modal.step-source.import-preview: 'Aperçu de l''import'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Rechercher'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Nom'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Données'
-data-importer.mapping.advanced-modal.loading: 'Chargement…'
-data-importer.mapping.advanced-modal.no-data: 'Aucune donnée'
-data-importer.mapping.advanced-modal.no-preview: 'Aucun aperçu disponible'
-data-importer.mapping.advanced-modal.step-target.type: 'Type'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Nom du champ'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Écraser'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Aperçu du résultat'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Étape précédente'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Confirmer le Mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Écrire dans ce champ même si le champ cible contient déjà une valeur'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Écrire dans ce champ même si les données source sont vides'
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Rechercher
+data-importer.mapping.advanced-modal.step-source.column-name: Nom
+data-importer.mapping.advanced-modal.step-source.column-data: Données
+data-importer.mapping.advanced-modal.loading: Chargement…
+data-importer.mapping.advanced-modal.no-data: Aucune donnée
+data-importer.mapping.advanced-modal.no-preview: Aucun aperçu disponible
+data-importer.mapping.advanced-modal.step-target.type: Type
+data-importer.mapping.advanced-modal.step-target.field-name: Nom du champ
+data-importer.mapping.advanced-modal.step-target.overwrite: Écraser
+data-importer.mapping.advanced-modal.step-target.preview-result: Aperçu du résultat
+data-importer.mapping.advanced-modal.step-target.previous-step: Étape précédente
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Confirmer le Mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Écrire dans ce champ même si le champ cible contient déjà une valeur
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Écrire dans ce champ même si les données source sont vides
 data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Mode d''écrasement'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Remplacer'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Fusionner'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Clé Classification Store'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'Aucune clé sélectionnée'
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Remplacer
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Fusionner
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Clé Classification Store
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: Aucune clé sélectionnée
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} dans le groupe {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Sélectionner une clé Classification Store'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Rechercher et sélectionner une clé pour ce champ Classification Store'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Sélectionner une clé Classification Store
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Rechercher et sélectionner une clé pour ce champ Classification Store
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch nécessite un type de résultat de transformation : array, quantityValueArray, inputQuantityValueArray ou dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation nécessite un type de résultat de transformation : advancedDataObject, dataObjectArray, assetArray ou advancedAssetArray.'
 
@@ -292,24 +292,24 @@ error.error_environment: 'Le fichier d''aperçu n''est pas valide pour l''interp
 
 # Execution Tab
 data-importer.execution.settings.title: 'Paramètres d''exécution'
-data-importer.execution.schedule-type: 'Type de planification'
-data-importer.execution.schedule-type.recurring: 'Récurrent / Cron'
-data-importer.execution.schedule-type.job: 'Tâche unique'
-data-importer.execution.cron-definition: 'Définition Cron'
-data-importer.execution.cron-generator: 'Générateur Cron'
-data-importer.execution.scheduled-at: 'Planifié le'
-data-importer.execution.manual-execution: 'Exécution manuelle'
+data-importer.execution.schedule-type: Type de planification
+data-importer.execution.schedule-type.recurring: Récurrent / Cron
+data-importer.execution.schedule-type.job: Tâche unique
+data-importer.execution.cron-definition: Définition Cron
+data-importer.execution.cron-generator: Générateur Cron
+data-importer.execution.scheduled-at: Planifié le
+data-importer.execution.manual-execution: Exécution manuelle
 data-importer.execution.start-import: 'Démarrer l''import'
-data-importer.execution.start-import.success: 'Import démarré avec succès'
+data-importer.execution.start-import.success: Import démarré avec succès
 data-importer.execution.start-import.error: 'Échec du démarrage de l''import'
 data-importer.execution.start-import.tooltip-dirty: 'Enregistrez vos modifications avant de démarrer l''import'
 data-importer.execution.start-import.tooltip-push: 'Le chargeur Push ne prend pas en charge l''exécution manuelle'
-data-importer.execution.cancel.success: 'Import annulé'
+data-importer.execution.cancel.success: Import annulé
 data-importer.execution.cancel.error: 'Échec de l''annulation de l''import'
 data-importer.execution.status.title: 'Statut d''exécution'
-data-importer.execution.status.not-running: 'Non en cours'
-data-importer.execution.status.finished: 'Tous les éléments ont été traités. Aucun import en cours.'
-data-importer.execution.status.current-progress: 'Progression actuelle'
+data-importer.execution.status.not-running: Non en cours
+data-importer.execution.status.finished: Tous les éléments ont été traités. Aucun import en cours.
+data-importer.execution.status.current-progress: Progression actuelle
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} éléments traités...'
 data-importer.execution.status.cancel: 'Annuler l''exécution et vider la file d''attente'
 data-importer.execution.cron-validating: 'Validation de l''expression Cron...'

--- a/src/Resources/translations/studio.it.yaml
+++ b/src/Resources/translations/studio.it.yaml
@@ -1,316 +1,316 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'Generale'
-data-importer.tabs.permissions: 'Permessi'
-data-importer.tabs.data-setup: 'Configurazione dati'
-data-importer.tabs.import-logs: 'Log di importazione'
-data-importer.tabs.execution: 'Esecuzione'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: Generale
+data-importer.tabs.permissions: Permessi
+data-importer.tabs.data-setup: Configurazione dati
+data-importer.tabs.import-logs: Log di importazione
+data-importer.tabs.execution: Esecuzione
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Origine dati'
+data-importer.data-setup.steps.data-source.title: Origine dati
 data-importer.data-setup.steps.data-source.description: 'Configura l''origine dati e il formato file'
-data-importer.data-setup.steps.preview-import.title: 'Anteprima importazione'
-data-importer.data-setup.steps.preview-import.description: 'Anteprima dei dati da importare'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Configura le regole di risoluzione dei dati'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Mappa i campi di origine sui campi di destinazione'
-data-importer.data-setup.steps.processing-settings.title: 'Impostazioni di elaborazione'
+data-importer.data-setup.steps.preview-import.title: Anteprima importazione
+data-importer.data-setup.steps.preview-import.description: Anteprima dei dati da importare
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Configura le regole di risoluzione dei dati
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Mappa i campi di origine sui campi di destinazione
+data-importer.data-setup.steps.processing-settings.title: Impostazioni di elaborazione
 data-importer.data-setup.steps.processing-settings.description: 'Configura le impostazioni di elaborazione dell''importazione'
 
 # Data Source
-data-importer.data-source.title: 'Origine dati'
-data-importer.data-source.type: 'Tipo'
-data-importer.data-source.type-label: 'Tipo di origine dati'
+data-importer.data-source.title: Origine dati
+data-importer.data-source.type: Tipo
+data-importer.data-source.type-label: Tipo di origine dati
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
-data-importer.loader.asset.asset-path: 'Percorso Asset'
+data-importer.loader.asset.asset-path: Percorso Asset
 
 # Upload Loader
-data-importer.loader.upload.status: 'Stato Upload'
-data-importer.loader.upload.file-uploaded: 'File caricato con successo'
-data-importer.loader.upload.no-file: 'Nessun file caricato'
-data-importer.loader.upload.file-path: 'Percorso del file caricato'
-data-importer.loader.upload.open-upload: 'Carica file'
-data-importer.loader.upload.modal-title: 'Carica file di importazione'
+data-importer.loader.upload.status: Stato Upload
+data-importer.loader.upload.file-uploaded: File caricato con successo
+data-importer.loader.upload.no-file: Nessun file caricato
+data-importer.loader.upload.file-path: Percorso del file caricato
+data-importer.loader.upload.open-upload: Carica file
+data-importer.loader.upload.modal-title: Carica file di importazione
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Host'
-data-importer.loader.sftp.port: 'Porta'
-data-importer.loader.sftp.username: 'Nome utente'
-data-importer.loader.sftp.password: 'Password'
-data-importer.loader.sftp.remote-path: 'Percorso remoto'
+data-importer.loader.sftp.host: Host
+data-importer.loader.sftp.port: Porta
+data-importer.loader.sftp.username: Nome utente
+data-importer.loader.sftp.password: Password
+data-importer.loader.sftp.remote-path: Percorso remoto
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Genera API Key'
-data-importer.loader.push.api-key-required: 'Inserire un API Key'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Genera API Key
+data-importer.loader.push.api-key-required: Inserire un API Key
 data-importer.loader.push.api-key-min-length: 'L''API Key deve essere lungo almeno 16 caratteri'
-data-importer.loader.push.ignore-not-empty-queue: 'Ignora coda non vuota'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.ignore-not-empty-queue: Ignora coda non vuota
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Connessione al database'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Connessione al database
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'Formato file'
-data-importer.file-format.type: 'Tipo'
+data-importer.file-format.title: Formato file
+data-importer.file-format.type: Tipo
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Delimitatore'
-data-importer.interpreter.csv.enclosure: 'Carattere di delimitazione'
-data-importer.interpreter.csv.escape: 'Carattere di escape'
+data-importer.interpreter.csv.delimiter: Delimitatore
+data-importer.interpreter.csv.enclosure: Carattere di delimitazione
+data-importer.interpreter.csv.escape: Carattere di escape
 data-importer.interpreter.csv.required: '{{field}} è obbligatorio'
 data-importer.interpreter.csv.single-char-only: '{{field}} deve essere vuoto o un singolo carattere'
-data-importer.interpreter.csv.skip-first-row: 'Salta la prima riga'
-data-importer.interpreter.csv.save-header-name: 'Salva nome intestazione'
+data-importer.interpreter.csv.skip-first-row: Salta la prima riga
+data-importer.interpreter.csv.save-header-name: Salva nome intestazione
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Percorso'
+data-importer.interpreter.json.path: Percorso
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Nome foglio'
-data-importer.interpreter.xlsx.skip-first-row: 'Salta la prima riga'
+data-importer.interpreter.xlsx.sheet-name: Nome foglio
+data-importer.interpreter.xlsx.skip-first-row: Salta la prima riga
 
 # SQL Interpreter
 data-importer.interpreter.sql.info: 'L''interprete SQL utilizza la configurazione della query del loader SQL.'
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Classe Data Object'
-data-importer.resolver.class-placeholder: 'Seleziona classe'
-data-importer.resolver.element-loading: 'Caricamento elemento'
-data-importer.resolver.loading-strategy: 'Strategia di caricamento'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Classe Data Object
+data-importer.resolver.class-placeholder: Seleziona classe
+data-importer.resolver.element-loading: Caricamento elemento
+data-importer.resolver.loading-strategy: Strategia di caricamento
 data-importer.resolver.loading-strategy.tooltip: 'Definisce come gli elementi esistenti vengono abbinati prima dell''importazione. Se non viene trovato alcun elemento, vengono applicate le regole di creazione.'
-data-importer.resolver.loading-strategy.notLoad: 'Nessun caricamento'
-data-importer.resolver.loading-strategy.id: 'Id'
-data-importer.resolver.loading-strategy.path: 'Percorso'
-data-importer.resolver.loading-strategy.attribute: 'Attributo'
-data-importer.resolver.loading-strategy.attribute-name: 'Nome attributo'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Seleziona attributo'
-data-importer.resolver.loading-strategy.data-source-index: 'Indice origine dati'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Seleziona colonna'
-data-importer.resolver.loading-strategy.language: 'Lingua'
-data-importer.resolver.loading-strategy.language-placeholder: 'Seleziona lingua'
-data-importer.resolver.loading-strategy.include-unpublished: 'Includi oggetti non pubblicati'
-data-importer.resolver.element-creation: 'Creazione elemento'
-data-importer.resolver.create-location-strategy: 'Strategia di posizionamento'
-data-importer.resolver.create-location-strategy.tooltip: 'Controlla dove vengono posizionati gli elementi appena creati quando non è stato risolto alcun elemento esistente.'
-data-importer.resolver.location-strategy.staticPath: 'Percorso statico'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Trova o crea cartella'
-data-importer.resolver.location-strategy.findParent: 'Trova elemento padre'
-data-importer.resolver.location-strategy.doNotCreate: 'Non creare'
-data-importer.resolver.location-strategy.noChange: 'Nessuna modifica'
-data-importer.resolver.location-strategy.path: 'Percorso'
-data-importer.resolver.location-strategy.path-placeholder: 'Inserisci percorso'
-data-importer.resolver.location-strategy.data-source-index: 'Indice origine dati'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Seleziona colonna'
-data-importer.resolver.location-strategy.fallback-path: 'Percorso di fallback'
-data-importer.resolver.location-strategy.fallback-path.tooltip: 'Utilizzato quando una posizione di destinazione dinamica non può essere risolta dai dati di origine.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Inserisci percorso di fallback'
-data-importer.resolver.location-strategy.find-strategy: 'Strategia di ricerca'
-data-importer.resolver.location-strategy.find-strategy.id: 'Per ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'Per percorso'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'Per attributo'
-data-importer.resolver.location-strategy.attribute-class: 'Classe'
-data-importer.resolver.location-strategy.attribute-name: 'Nome attributo'
-data-importer.resolver.location-strategy.attribute-language: 'Lingua'
-data-importer.resolver.location-strategy.as-variant: 'Come variante'
-data-importer.resolver.element-location-update: 'Aggiornamento posizione elemento'
-data-importer.resolver.location-update-strategy: 'Strategia di posizionamento'
+data-importer.resolver.loading-strategy.notLoad: Nessun caricamento
+data-importer.resolver.loading-strategy.id: Id
+data-importer.resolver.loading-strategy.path: Percorso
+data-importer.resolver.loading-strategy.attribute: Attributo
+data-importer.resolver.loading-strategy.attribute-name: Nome attributo
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Seleziona attributo
+data-importer.resolver.loading-strategy.data-source-index: Indice origine dati
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Seleziona colonna
+data-importer.resolver.loading-strategy.language: Lingua
+data-importer.resolver.loading-strategy.language-placeholder: Seleziona lingua
+data-importer.resolver.loading-strategy.include-unpublished: Includi oggetti non pubblicati
+data-importer.resolver.element-creation: Creazione elemento
+data-importer.resolver.create-location-strategy: Strategia di posizionamento
+data-importer.resolver.create-location-strategy.tooltip: Controlla dove vengono posizionati gli elementi appena creati quando non è stato risolto alcun elemento esistente.
+data-importer.resolver.location-strategy.staticPath: Percorso statico
+data-importer.resolver.location-strategy.findOrCreateFolder: Trova o crea cartella
+data-importer.resolver.location-strategy.findParent: Trova elemento padre
+data-importer.resolver.location-strategy.doNotCreate: Non creare
+data-importer.resolver.location-strategy.noChange: Nessuna modifica
+data-importer.resolver.location-strategy.path: Percorso
+data-importer.resolver.location-strategy.path-placeholder: Inserisci percorso
+data-importer.resolver.location-strategy.data-source-index: Indice origine dati
+data-importer.resolver.location-strategy.data-source-index-placeholder: Seleziona colonna
+data-importer.resolver.location-strategy.fallback-path: Percorso di fallback
+data-importer.resolver.location-strategy.fallback-path.tooltip: Utilizzato quando una posizione di destinazione dinamica non può essere risolta dai dati di origine.
+data-importer.resolver.location-strategy.fallback-path-placeholder: Inserisci percorso di fallback
+data-importer.resolver.location-strategy.find-strategy: Strategia di ricerca
+data-importer.resolver.location-strategy.find-strategy.id: Per ID
+data-importer.resolver.location-strategy.find-strategy.path: Per percorso
+data-importer.resolver.location-strategy.find-strategy.attribute: Per attributo
+data-importer.resolver.location-strategy.attribute-class: Classe
+data-importer.resolver.location-strategy.attribute-name: Nome attributo
+data-importer.resolver.location-strategy.attribute-language: Lingua
+data-importer.resolver.location-strategy.as-variant: Come variante
+data-importer.resolver.element-location-update: Aggiornamento posizione elemento
+data-importer.resolver.location-update-strategy: Strategia di posizionamento
 data-importer.resolver.location-update-strategy.tooltip: 'Controlla se e come la posizione degli elementi già risolti viene modificata durante l''importazione.'
-data-importer.resolver.element-publishing: 'Pubblicazione elemento'
-data-importer.resolver.publishing-strategy: 'Strategia di pubblicazione'
-data-importer.resolver.publishing-strategy.tooltip: 'Definisce il comportamento di pubblicazione o revoca della pubblicazione per gli elementi importati.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'Nessuna modifica / Nuovi non pubblicati'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'Nessuna modifica / Nuovi pubblicati'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Pubblica sempre'
-data-importer.resolver.publishing-strategy.attributeBased: 'Basato su attributo'
-data-importer.resolver.publishing-strategy.data-source-index: 'Indice origine dati'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Seleziona colonna'
+data-importer.resolver.element-publishing: Pubblicazione elemento
+data-importer.resolver.publishing-strategy: Strategia di pubblicazione
+data-importer.resolver.publishing-strategy.tooltip: Definisce il comportamento di pubblicazione o revoca della pubblicazione per gli elementi importati.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: Nessuna modifica / Nuovi non pubblicati
+data-importer.resolver.publishing-strategy.noChangePublishNew: Nessuna modifica / Nuovi pubblicati
+data-importer.resolver.publishing-strategy.alwaysPublish: Pubblica sempre
+data-importer.resolver.publishing-strategy.attributeBased: Basato su attributo
+data-importer.resolver.publishing-strategy.data-source-index: Indice origine dati
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Seleziona colonna
 
 # Processing Settings
-data-importer.processing.title: 'Impostazioni di elaborazione'
-data-importer.processing.execution.title: 'Esecuzione'
-data-importer.processing.id-delta.title: 'ID, Delta Check e pulizia'
-data-importer.processing.execution-type: 'Tipo di esecuzione'
-data-importer.processing.execution-type.tooltip: 'Sequenziale elabora un elemento alla volta. Parallelo elabora più elementi contemporaneamente.'
-data-importer.processing.execution-type.sequential: 'Sequenziale'
-data-importer.processing.execution-type.parallel: 'Parallelo'
-data-importer.processing.archive-import-file: 'Archivia file di importazione'
-data-importer.processing.disable-versioning: 'Disabilita versionamento'
-data-importer.processing.id-data-index: 'Indice dati del campo ID'
-data-importer.processing.id-data-index.tooltip: 'Colonna utilizzata come identificatore stabile per Delta Check e pulizia. Queste opzioni sono disponibili solo quando è impostato un indice dati ID.'
-data-importer.processing.id-data-index-placeholder: 'Seleziona colonna'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Pulizia'
-data-importer.processing.cleanup.do-cleanup: 'Pulisci elementi non importati'
-data-importer.processing.cleanup.strategy: 'Strategia di pulizia'
+data-importer.processing.title: Impostazioni di elaborazione
+data-importer.processing.execution.title: Esecuzione
+data-importer.processing.id-delta.title: ID, Delta Check e pulizia
+data-importer.processing.execution-type: Tipo di esecuzione
+data-importer.processing.execution-type.tooltip: Sequenziale elabora un elemento alla volta. Parallelo elabora più elementi contemporaneamente.
+data-importer.processing.execution-type.sequential: Sequenziale
+data-importer.processing.execution-type.parallel: Parallelo
+data-importer.processing.archive-import-file: Archivia file di importazione
+data-importer.processing.disable-versioning: Disabilita versionamento
+data-importer.processing.id-data-index: Indice dati del campo ID
+data-importer.processing.id-data-index.tooltip: Colonna utilizzata come identificatore stabile per Delta Check e pulizia. Queste opzioni sono disponibili solo quando è impostato un indice dati ID.
+data-importer.processing.id-data-index-placeholder: Seleziona colonna
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Pulizia
+data-importer.processing.cleanup.do-cleanup: Pulisci elementi non importati
+data-importer.processing.cleanup.strategy: Strategia di pulizia
 data-importer.processing.cleanup.strategy.tooltip: 'Determina cosa succede agli elementi esistenti che non sono presenti nell''importazione corrente.'
-data-importer.processing.cleanup.strategy.delete: 'Elimina'
-data-importer.processing.cleanup.strategy.unpublish: 'Revoca pubblicazione'
-data-importer.processing.logging.title: 'Impostazioni di logging (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Disabilita log informativi'
-data-importer.processing.logging.info.disable-file-objects: 'Disabilita file object informativi'
-data-importer.processing.logging.error.title: 'Errore'
-data-importer.processing.logging.error.disable-logs: 'Disabilita log di errore'
-data-importer.processing.logging.error.disable-file-objects: 'Disabilita file object di errore'
+data-importer.processing.cleanup.strategy.delete: Elimina
+data-importer.processing.cleanup.strategy.unpublish: Revoca pubblicazione
+data-importer.processing.logging.title: Impostazioni di logging (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Disabilita log informativi
+data-importer.processing.logging.info.disable-file-objects: Disabilita file object informativi
+data-importer.processing.logging.error.title: Errore
+data-importer.processing.logging.error.disable-logs: Disabilita log di errore
+data-importer.processing.logging.error.disable-file-objects: Disabilita file object di errore
 
 # Preview Import
-data-importer.preview-import.title: 'Anteprima importazione'
-data-importer.preview-import.choose-preview-data: 'Scegli i dati di anteprima'
-data-importer.preview-import.upload-file: 'Carica file'
+data-importer.preview-import.title: Anteprima importazione
+data-importer.preview-import.choose-preview-data: Scegli i dati di anteprima
+data-importer.preview-import.upload-file: Carica file
 data-importer.preview-import.copy-from-source: 'Copia dall''origine dati'
-data-importer.preview-import.search-placeholder: 'Cerca per nome, origine, destinazione'
-data-importer.preview-import.column.label: 'Etichetta'
-data-importer.preview-import.column.data: 'Dati'
-data-importer.preview-import.prev: 'Record precedente'
-data-importer.preview-import.next: 'Record successivo'
+data-importer.preview-import.search-placeholder: Cerca per nome, origine, destinazione
+data-importer.preview-import.column.label: Etichetta
+data-importer.preview-import.column.data: Dati
+data-importer.preview-import.prev: Record precedente
+data-importer.preview-import.next: Record successivo
 
 # Mapping
-data-importer.mapping.title: 'Configurazione Mapping'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'Nuovo'
-data-importer.mapping.new-modal.title: 'Nuovo Mapping'
-data-importer.mapping.new-modal.source-label: 'Colonna di origine'
-data-importer.mapping.new-modal.source-required: 'Selezionare una colonna di origine'
-data-importer.mapping.collapse-all: 'Comprimi tutti'
-data-importer.mapping.expand-all: 'Espandi tutti'
-data-importer.mapping.auto-fill: 'Compilazione automatica'
-data-importer.mapping.empty-state: 'Inizia a creare un Mapping direttamente dalla colonna Origini, oppure fai clic su Nuovo per crearne uno manualmente.'
+data-importer.mapping.title: Configurazione Mapping
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: Nuovo
+data-importer.mapping.new-modal.title: Nuovo Mapping
+data-importer.mapping.new-modal.source-label: Colonna di origine
+data-importer.mapping.new-modal.source-required: Selezionare una colonna di origine
+data-importer.mapping.collapse-all: Comprimi tutti
+data-importer.mapping.expand-all: Espandi tutti
+data-importer.mapping.auto-fill: Compilazione automatica
+data-importer.mapping.empty-state: Inizia a creare un Mapping direttamente dalla colonna Origini, oppure fai clic su Nuovo per crearne uno manualmente.
 data-importer.mapping.filter-empty: 'Nessun Mapping per "{{source}}" ancora.'
-data-importer.mapping.sources.title: 'Origini con anteprima'
-data-importer.mapping.sources.reset-view: 'Reimposta vista'
+data-importer.mapping.sources.title: Origini con anteprima
+data-importer.mapping.sources.reset-view: Reimposta vista
 data-importer.mapping.sources.empty: 'Nessun dato di anteprima disponibile. Configurare un''origine dati ed eseguire un''anteprima importazione.'
-data-importer.mapping.item.new-label: 'Nuovo Mapping'
-data-importer.mapping.item.label: 'Etichetta'
-data-importer.mapping.item.advanced: 'Avanzate'
-data-importer.mapping.item.delete: 'Elimina Mapping'
-data-importer.mapping.item.source: 'Origine'
-data-importer.mapping.item.source-placeholder: 'Seleziona colonne di origine'
-data-importer.mapping.item.destination: 'Destinazione'
-data-importer.mapping.item.destination-placeholder: 'Seleziona campo'
-data-importer.mapping.item.requires-advanced-setup: 'Richiede configurazione avanzata'
-data-importer.mapping.item.data-source-index: 'Indice origine dati'
-data-importer.mapping.item.data-source-index-placeholder: 'Seleziona colonne di origine'
-data-importer.mapping.item.transformation-pipeline.title: 'Pipeline di trasformazione'
-data-importer.mapping.item.transformation-pipeline.empty: 'Nessuna Pipeline di trasformazione configurata'
-data-importer.mapping.item.transformation-result.title: 'Risultato trasformazione'
-data-importer.mapping.item.transformation-result.type: 'Tipo di risultato'
-data-importer.mapping.item.data-target.title: 'Destinazione dati'
-data-importer.mapping.item.data-target.type: 'Tipo di destinazione'
-data-importer.mapping.item.data-target.type-placeholder: 'Seleziona tipo di destinazione'
-data-importer.mapping.item.data-target.type.direct: 'Diretto'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Nome campo'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Seleziona campo'
-data-importer.mapping.item.data-target.language: 'Lingua'
-data-importer.mapping.item.data-target.language-placeholder: 'Seleziona lingua'
-data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Scrivi se la destinazione non è vuota'
+data-importer.mapping.item.new-label: Nuovo Mapping
+data-importer.mapping.item.label: Etichetta
+data-importer.mapping.item.advanced: Avanzate
+data-importer.mapping.item.delete: Elimina Mapping
+data-importer.mapping.item.source: Origine
+data-importer.mapping.item.source-placeholder: Seleziona colonne di origine
+data-importer.mapping.item.destination: Destinazione
+data-importer.mapping.item.destination-placeholder: Seleziona campo
+data-importer.mapping.item.requires-advanced-setup: Richiede configurazione avanzata
+data-importer.mapping.item.data-source-index: Indice origine dati
+data-importer.mapping.item.data-source-index-placeholder: Seleziona colonne di origine
+data-importer.mapping.item.transformation-pipeline.title: Pipeline di trasformazione
+data-importer.mapping.item.transformation-pipeline.empty: Nessuna Pipeline di trasformazione configurata
+data-importer.mapping.item.transformation-result.title: Risultato trasformazione
+data-importer.mapping.item.transformation-result.type: Tipo di risultato
+data-importer.mapping.item.data-target.title: Destinazione dati
+data-importer.mapping.item.data-target.type: Tipo di destinazione
+data-importer.mapping.item.data-target.type-placeholder: Seleziona tipo di destinazione
+data-importer.mapping.item.data-target.type.direct: Diretto
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Nome campo
+data-importer.mapping.item.data-target.field-name-placeholder: Seleziona campo
+data-importer.mapping.item.data-target.language: Lingua
+data-importer.mapping.item.data-target.language-placeholder: Seleziona lingua
+data-importer.mapping.item.data-target.write-if-target-is-not-empty: Scrivi se la destinazione non è vuota
 data-importer.mapping.item.data-target.write-if-source-is-empty: 'Scrivi se l''origine è vuota'
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Modifica Mapping e trasformazioni'
-data-importer.mapping.advanced-modal.save: 'Salva'
-data-importer.mapping.advanced-modal.step-source: 'Origine'
-data-importer.mapping.advanced-modal.step-transformations: 'Trasformazioni'
-data-importer.mapping.advanced-modal.step-target: 'Destinazione dati'
-data-importer.mapping.advanced-modal.no-transformers: 'Nessun trasformatore configurato. Aggiungerne uno qui sotto.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Aggiungi trasformazione'
-data-importer.mapping.advanced-modal.result-type: 'Tipo di risultato'
-data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Scrivi se la destinazione non è vuota'
+data-importer.mapping.advanced-modal.title: Modifica Mapping e trasformazioni
+data-importer.mapping.advanced-modal.save: Salva
+data-importer.mapping.advanced-modal.step-source: Origine
+data-importer.mapping.advanced-modal.step-transformations: Trasformazioni
+data-importer.mapping.advanced-modal.step-target: Destinazione dati
+data-importer.mapping.advanced-modal.no-transformers: Nessun trasformatore configurato. Aggiungerne uno qui sotto.
+data-importer.mapping.advanced-modal.add-transformation: + Aggiungi trasformazione
+data-importer.mapping.advanced-modal.result-type: Tipo di risultato
+data-importer.mapping.advanced-modal.write-if-target-not-empty: Scrivi se la destinazione non è vuota
 data-importer.mapping.advanced-modal.write-if-source-empty: 'Scrivi se l''origine è vuota'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Sposta su'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Sposta giù'
-data-importer.mapping.advanced-modal.transformer.remove: 'Rimuovi'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Modifica attributi di origine'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Manipolazione dati'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Tipi di dati'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Caricamento / Importazione'
-data-importer.mapping.advanced-modal.next-step: 'Passaggio successivo'
-data-importer.mapping.advanced-modal.previous-step: 'Passaggio precedente'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Ricalcola il tipo di risultato della trasformazione'
-data-importer.mapping.advanced-modal.step-source.label: 'Attributo/i di origine'
+data-importer.mapping.advanced-modal.transformer.move-up: Sposta su
+data-importer.mapping.advanced-modal.transformer.move-down: Sposta giù
+data-importer.mapping.advanced-modal.transformer.remove: Rimuovi
+data-importer.mapping.advanced-modal.transformer.edit-source: Modifica attributi di origine
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Manipolazione dati
+data-importer.mapping.advanced-modal.transformer.group.data-types: Tipi di dati
+data-importer.mapping.advanced-modal.transformer.group.load-import: Caricamento / Importazione
+data-importer.mapping.advanced-modal.next-step: Passaggio successivo
+data-importer.mapping.advanced-modal.previous-step: Passaggio precedente
+data-importer.mapping.advanced-modal.recalculate-result-type: Ricalcola il tipo di risultato della trasformazione
+data-importer.mapping.advanced-modal.step-source.label: Attributo/i di origine
 data-importer.mapping.advanced-modal.step-source.description: 'Scegliere dall''elenco o aggiungere una nuova origine'
-data-importer.mapping.advanced-modal.step-source.import-preview: 'Anteprima importazione'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Cerca'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Nome'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Dati'
-data-importer.mapping.advanced-modal.loading: 'Caricamento…'
-data-importer.mapping.advanced-modal.no-data: 'Nessun dato'
-data-importer.mapping.advanced-modal.no-preview: 'Nessuna anteprima disponibile'
-data-importer.mapping.advanced-modal.step-target.type: 'Tipo'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Nome campo'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Sovrascrittura'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Risultato anteprima'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Passaggio precedente'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Conferma Mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Scrivi in questo campo anche se il campo di destinazione contiene già un valore'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Scrivi in questo campo anche se i dati di origine sono vuoti'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Modalità di sovrascrittura'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Sostituisci'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Unisci'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Chiave Classification Store'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'Nessuna chiave selezionata'
+data-importer.mapping.advanced-modal.step-source.import-preview: Anteprima importazione
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Cerca
+data-importer.mapping.advanced-modal.step-source.column-name: Nome
+data-importer.mapping.advanced-modal.step-source.column-data: Dati
+data-importer.mapping.advanced-modal.loading: Caricamento…
+data-importer.mapping.advanced-modal.no-data: Nessun dato
+data-importer.mapping.advanced-modal.no-preview: Nessuna anteprima disponibile
+data-importer.mapping.advanced-modal.step-target.type: Tipo
+data-importer.mapping.advanced-modal.step-target.field-name: Nome campo
+data-importer.mapping.advanced-modal.step-target.overwrite: Sovrascrittura
+data-importer.mapping.advanced-modal.step-target.preview-result: Risultato anteprima
+data-importer.mapping.advanced-modal.step-target.previous-step: Passaggio precedente
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Conferma Mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Scrivi in questo campo anche se il campo di destinazione contiene già un valore
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Scrivi in questo campo anche se i dati di origine sono vuoti
+data-importer.mapping.advanced-modal.step-target.overwrite-mode: Modalità di sovrascrittura
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Sostituisci
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Unisci
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Chiave Classification Store
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: Nessuna chiave selezionata
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} nel gruppo {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Seleziona chiave Classification Store'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Cerca e seleziona una chiave per questo campo Classification Store'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Seleziona chiave Classification Store
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Cerca e seleziona una chiave per questo campo Classification Store
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch richiede il tipo di risultato della trasformazione: array, quantityValueArray, inputQuantityValueArray o dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation richiede il tipo di risultato della trasformazione: advancedDataObject, dataObjectArray, assetArray o advancedAssetArray.'
 
 error.error_environment: 'Il file di anteprima non è valido per l''interprete configurato. Ricaricare o ricopiare i dati di anteprima.'
 
 # Execution Tab
-data-importer.execution.settings.title: 'Impostazioni di esecuzione'
-data-importer.execution.schedule-type: 'Tipo di pianificazione'
-data-importer.execution.schedule-type.recurring: 'Ricorrente / Cron'
-data-importer.execution.schedule-type.job: 'Esecuzione singola'
-data-importer.execution.cron-definition: 'Definizione Cron'
-data-importer.execution.cron-generator: 'Generatore Cron'
-data-importer.execution.scheduled-at: 'Pianificato per'
-data-importer.execution.manual-execution: 'Esecuzione manuale'
-data-importer.execution.start-import: 'Avvia importazione'
-data-importer.execution.start-import.success: 'Importazione avviata con successo'
+data-importer.execution.settings.title: Impostazioni di esecuzione
+data-importer.execution.schedule-type: Tipo di pianificazione
+data-importer.execution.schedule-type.recurring: Ricorrente / Cron
+data-importer.execution.schedule-type.job: Esecuzione singola
+data-importer.execution.cron-definition: Definizione Cron
+data-importer.execution.cron-generator: Generatore Cron
+data-importer.execution.scheduled-at: Pianificato per
+data-importer.execution.manual-execution: Esecuzione manuale
+data-importer.execution.start-import: Avvia importazione
+data-importer.execution.start-import.success: Importazione avviata con successo
 data-importer.execution.start-import.error: 'Impossibile avviare l''importazione'
 data-importer.execution.start-import.tooltip-dirty: 'Salvare le modifiche prima di avviare l''importazione'
 data-importer.execution.start-import.tooltip-push: 'Il loader Push non supporta l''esecuzione manuale'
-data-importer.execution.cancel.success: 'Importazione annullata'
+data-importer.execution.cancel.success: Importazione annullata
 data-importer.execution.cancel.error: 'Impossibile annullare l''importazione'
-data-importer.execution.status.title: 'Stato di esecuzione'
-data-importer.execution.status.not-running: 'Non in esecuzione'
-data-importer.execution.status.finished: 'Tutti gli elementi elaborati. Nessuna importazione in corso.'
-data-importer.execution.status.current-progress: 'Avanzamento corrente'
+data-importer.execution.status.title: Stato di esecuzione
+data-importer.execution.status.not-running: Non in esecuzione
+data-importer.execution.status.finished: Tutti gli elementi elaborati. Nessuna importazione in corso.
+data-importer.execution.status.current-progress: Avanzamento corrente
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} elementi elaborati...'
-data-importer.execution.status.cancel: 'Annulla esecuzione e svuota la coda'
+data-importer.execution.status.cancel: Annulla esecuzione e svuota la coda
 data-importer.execution.cron-validating: 'Validazione dell''espressione Cron...'
 data-importer.validation.required: '{{field}} è obbligatorio'

--- a/src/Resources/translations/studio.no.yaml
+++ b/src/Resources/translations/studio.no.yaml
@@ -1,316 +1,316 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'Generelt'
-data-importer.tabs.permissions: 'Tillatelser'
-data-importer.tabs.data-setup: 'Dataoppsett'
-data-importer.tabs.import-logs: 'Importlogger'
-data-importer.tabs.execution: 'Kjøring'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: Generelt
+data-importer.tabs.permissions: Tillatelser
+data-importer.tabs.data-setup: Dataoppsett
+data-importer.tabs.import-logs: Importlogger
+data-importer.tabs.execution: Kjøring
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Datakilde'
-data-importer.data-setup.steps.data-source.description: 'Konfigurer datakilde og filformat'
-data-importer.data-setup.steps.preview-import.title: 'Importforhåndsvisning'
-data-importer.data-setup.steps.preview-import.description: 'Forhåndsvis dataene som skal importeres'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Konfigurer regler for dataoppløsning'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Koble kildefelt til målfelt'
-data-importer.data-setup.steps.processing-settings.title: 'Behandlingsinnstillinger'
-data-importer.data-setup.steps.processing-settings.description: 'Konfigurer innstillinger for importbehandling'
+data-importer.data-setup.steps.data-source.title: Datakilde
+data-importer.data-setup.steps.data-source.description: Konfigurer datakilde og filformat
+data-importer.data-setup.steps.preview-import.title: Importforhåndsvisning
+data-importer.data-setup.steps.preview-import.description: Forhåndsvis dataene som skal importeres
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Konfigurer regler for dataoppløsning
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Koble kildefelt til målfelt
+data-importer.data-setup.steps.processing-settings.title: Behandlingsinnstillinger
+data-importer.data-setup.steps.processing-settings.description: Konfigurer innstillinger for importbehandling
 
 # Data Source
-data-importer.data-source.title: 'Datakilde'
-data-importer.data-source.type: 'Type'
-data-importer.data-source.type-label: 'Datakildetype'
+data-importer.data-source.title: Datakilde
+data-importer.data-source.type: Type
+data-importer.data-source.type-label: Datakildetype
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
-data-importer.loader.asset.asset-path: 'Asset-sti'
+data-importer.loader.asset.asset-path: Asset-sti
 
 # Upload Loader
-data-importer.loader.upload.status: 'Upload-status'
-data-importer.loader.upload.file-uploaded: 'Filen ble lastet opp'
-data-importer.loader.upload.no-file: 'Ingen fil lastet opp ennå'
-data-importer.loader.upload.file-path: 'Sti til opplastet fil'
-data-importer.loader.upload.open-upload: 'Last opp fil'
-data-importer.loader.upload.modal-title: 'Last opp importfil'
+data-importer.loader.upload.status: Upload-status
+data-importer.loader.upload.file-uploaded: Filen ble lastet opp
+data-importer.loader.upload.no-file: Ingen fil lastet opp ennå
+data-importer.loader.upload.file-path: Sti til opplastet fil
+data-importer.loader.upload.open-upload: Last opp fil
+data-importer.loader.upload.modal-title: Last opp importfil
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Host'
-data-importer.loader.sftp.port: 'Port'
-data-importer.loader.sftp.username: 'Brukernavn'
-data-importer.loader.sftp.password: 'Passord'
-data-importer.loader.sftp.remote-path: 'Ekstern sti'
+data-importer.loader.sftp.host: Host
+data-importer.loader.sftp.port: Port
+data-importer.loader.sftp.username: Brukernavn
+data-importer.loader.sftp.password: Passord
+data-importer.loader.sftp.remote-path: Ekstern sti
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Generer API Key'
-data-importer.loader.push.api-key-required: 'Vennligst oppgi en API Key'
-data-importer.loader.push.api-key-min-length: 'API Key må være minst 16 tegn lang'
-data-importer.loader.push.ignore-not-empty-queue: 'Ignorer ikke-tom kø'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Generer API Key
+data-importer.loader.push.api-key-required: Vennligst oppgi en API Key
+data-importer.loader.push.api-key-min-length: API Key må være minst 16 tegn lang
+data-importer.loader.push.ignore-not-empty-queue: Ignorer ikke-tom kø
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Databasetilkobling'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Databasetilkobling
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'Filformat'
-data-importer.file-format.type: 'Type'
+data-importer.file-format.title: Filformat
+data-importer.file-format.type: Type
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Skilletegn'
-data-importer.interpreter.csv.enclosure: 'Tekstbegrensning'
-data-importer.interpreter.csv.escape: 'Escape-tegn'
+data-importer.interpreter.csv.delimiter: Skilletegn
+data-importer.interpreter.csv.enclosure: Tekstbegrensning
+data-importer.interpreter.csv.escape: Escape-tegn
 data-importer.interpreter.csv.required: '{{field}} er påkrevd'
 data-importer.interpreter.csv.single-char-only: '{{field}} må være tomt eller ett enkelt tegn'
-data-importer.interpreter.csv.skip-first-row: 'Hopp over første rad'
-data-importer.interpreter.csv.save-header-name: 'Lagre overskriftsnavn'
+data-importer.interpreter.csv.skip-first-row: Hopp over første rad
+data-importer.interpreter.csv.save-header-name: Lagre overskriftsnavn
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Sti'
+data-importer.interpreter.json.path: Sti
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Arknavn'
-data-importer.interpreter.xlsx.skip-first-row: 'Hopp over første rad'
+data-importer.interpreter.xlsx.sheet-name: Arknavn
+data-importer.interpreter.xlsx.skip-first-row: Hopp over første rad
 
 # SQL Interpreter
-data-importer.interpreter.sql.info: 'SQL-tolken bruker spørringskonfigurasjonen fra SQL-lasteren.'
+data-importer.interpreter.sql.info: SQL-tolken bruker spørringskonfigurasjonen fra SQL-lasteren.
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Data-Object-klasse'
-data-importer.resolver.class-placeholder: 'Velg klasse'
-data-importer.resolver.element-loading: 'Elementlasting'
-data-importer.resolver.loading-strategy: 'Lastestrategi'
-data-importer.resolver.loading-strategy.tooltip: 'Definerer hvordan eksisterende elementer matches før import. Hvis ingen elementer finnes, brukes opprettelsesreglene.'
-data-importer.resolver.loading-strategy.notLoad: 'Ingen lasting'
-data-importer.resolver.loading-strategy.id: 'ID'
-data-importer.resolver.loading-strategy.path: 'Sti'
-data-importer.resolver.loading-strategy.attribute: 'Attributt'
-data-importer.resolver.loading-strategy.attribute-name: 'Attributtnavn'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Velg attributt'
-data-importer.resolver.loading-strategy.data-source-index: 'Datakildeindeks'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Velg kolonne'
-data-importer.resolver.loading-strategy.language: 'Språk'
-data-importer.resolver.loading-strategy.language-placeholder: 'Velg språk'
-data-importer.resolver.loading-strategy.include-unpublished: 'Inkluder upubliserte objekter'
-data-importer.resolver.element-creation: 'Elementopprettelse'
-data-importer.resolver.create-location-strategy: 'Plasseringsstrategi'
-data-importer.resolver.create-location-strategy.tooltip: 'Styrer hvor nyopprettede elementer plasseres når ingen eksisterende elementer ble funnet.'
-data-importer.resolver.location-strategy.staticPath: 'Statisk sti'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Finn eller opprett mappe'
-data-importer.resolver.location-strategy.findParent: 'Finn overordnet element'
-data-importer.resolver.location-strategy.doNotCreate: 'Ikke opprett'
-data-importer.resolver.location-strategy.noChange: 'Ingen endring'
-data-importer.resolver.location-strategy.path: 'Sti'
-data-importer.resolver.location-strategy.path-placeholder: 'Skriv inn sti'
-data-importer.resolver.location-strategy.data-source-index: 'Datakildeindeks'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Velg kolonne'
-data-importer.resolver.location-strategy.fallback-path: 'Reservesti'
-data-importer.resolver.location-strategy.fallback-path.tooltip: 'Brukes når en dynamisk målplassering ikke kan utledes fra kildedataene.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Skriv inn reservesti'
-data-importer.resolver.location-strategy.find-strategy: 'Søkestrategi'
-data-importer.resolver.location-strategy.find-strategy.id: 'Etter ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'Etter sti'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'Etter attributt'
-data-importer.resolver.location-strategy.attribute-class: 'Klasse'
-data-importer.resolver.location-strategy.attribute-name: 'Attributtnavn'
-data-importer.resolver.location-strategy.attribute-language: 'Språk'
-data-importer.resolver.location-strategy.as-variant: 'Som variant'
-data-importer.resolver.element-location-update: 'Oppdatering av elementplassering'
-data-importer.resolver.location-update-strategy: 'Plasseringsstrategi'
-data-importer.resolver.location-update-strategy.tooltip: 'Styrer om og hvordan plasseringen til allerede funne elementer endres under import.'
-data-importer.resolver.element-publishing: 'Elementpublisering'
-data-importer.resolver.publishing-strategy: 'Publiseringsstrategi'
-data-importer.resolver.publishing-strategy.tooltip: 'Definerer publiserings- eller avpubliseringsatferd for importerte elementer.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'Ingen endring / Avpubliser nye'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'Ingen endring / Publiser nye'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Alltid publiser'
-data-importer.resolver.publishing-strategy.attributeBased: 'Attributtbasert'
-data-importer.resolver.publishing-strategy.data-source-index: 'Datakildeindeks'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Velg kolonne'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Data-Object-klasse
+data-importer.resolver.class-placeholder: Velg klasse
+data-importer.resolver.element-loading: Elementlasting
+data-importer.resolver.loading-strategy: Lastestrategi
+data-importer.resolver.loading-strategy.tooltip: Definerer hvordan eksisterende elementer matches før import. Hvis ingen elementer finnes, brukes opprettelsesreglene.
+data-importer.resolver.loading-strategy.notLoad: Ingen lasting
+data-importer.resolver.loading-strategy.id: ID
+data-importer.resolver.loading-strategy.path: Sti
+data-importer.resolver.loading-strategy.attribute: Attributt
+data-importer.resolver.loading-strategy.attribute-name: Attributtnavn
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Velg attributt
+data-importer.resolver.loading-strategy.data-source-index: Datakildeindeks
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Velg kolonne
+data-importer.resolver.loading-strategy.language: Språk
+data-importer.resolver.loading-strategy.language-placeholder: Velg språk
+data-importer.resolver.loading-strategy.include-unpublished: Inkluder upubliserte objekter
+data-importer.resolver.element-creation: Elementopprettelse
+data-importer.resolver.create-location-strategy: Plasseringsstrategi
+data-importer.resolver.create-location-strategy.tooltip: Styrer hvor nyopprettede elementer plasseres når ingen eksisterende elementer ble funnet.
+data-importer.resolver.location-strategy.staticPath: Statisk sti
+data-importer.resolver.location-strategy.findOrCreateFolder: Finn eller opprett mappe
+data-importer.resolver.location-strategy.findParent: Finn overordnet element
+data-importer.resolver.location-strategy.doNotCreate: Ikke opprett
+data-importer.resolver.location-strategy.noChange: Ingen endring
+data-importer.resolver.location-strategy.path: Sti
+data-importer.resolver.location-strategy.path-placeholder: Skriv inn sti
+data-importer.resolver.location-strategy.data-source-index: Datakildeindeks
+data-importer.resolver.location-strategy.data-source-index-placeholder: Velg kolonne
+data-importer.resolver.location-strategy.fallback-path: Reservesti
+data-importer.resolver.location-strategy.fallback-path.tooltip: Brukes når en dynamisk målplassering ikke kan utledes fra kildedataene.
+data-importer.resolver.location-strategy.fallback-path-placeholder: Skriv inn reservesti
+data-importer.resolver.location-strategy.find-strategy: Søkestrategi
+data-importer.resolver.location-strategy.find-strategy.id: Etter ID
+data-importer.resolver.location-strategy.find-strategy.path: Etter sti
+data-importer.resolver.location-strategy.find-strategy.attribute: Etter attributt
+data-importer.resolver.location-strategy.attribute-class: Klasse
+data-importer.resolver.location-strategy.attribute-name: Attributtnavn
+data-importer.resolver.location-strategy.attribute-language: Språk
+data-importer.resolver.location-strategy.as-variant: Som variant
+data-importer.resolver.element-location-update: Oppdatering av elementplassering
+data-importer.resolver.location-update-strategy: Plasseringsstrategi
+data-importer.resolver.location-update-strategy.tooltip: Styrer om og hvordan plasseringen til allerede funne elementer endres under import.
+data-importer.resolver.element-publishing: Elementpublisering
+data-importer.resolver.publishing-strategy: Publiseringsstrategi
+data-importer.resolver.publishing-strategy.tooltip: Definerer publiserings- eller avpubliseringsatferd for importerte elementer.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: Ingen endring / Avpubliser nye
+data-importer.resolver.publishing-strategy.noChangePublishNew: Ingen endring / Publiser nye
+data-importer.resolver.publishing-strategy.alwaysPublish: Alltid publiser
+data-importer.resolver.publishing-strategy.attributeBased: Attributtbasert
+data-importer.resolver.publishing-strategy.data-source-index: Datakildeindeks
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Velg kolonne
 
 # Processing Settings
-data-importer.processing.title: 'Behandlingsinnstillinger'
-data-importer.processing.execution.title: 'Kjøring'
-data-importer.processing.id-delta.title: 'ID, Delta Check og opprydding'
-data-importer.processing.execution-type: 'Kjøringstype'
-data-importer.processing.execution-type.tooltip: 'Sekvensiell behandler ett element om gangen. Parallell behandler flere elementer samtidig.'
-data-importer.processing.execution-type.sequential: 'Sekvensiell'
-data-importer.processing.execution-type.parallel: 'Parallell'
-data-importer.processing.archive-import-file: 'Arkiver importfil'
-data-importer.processing.disable-versioning: 'Deaktiver versjonering'
-data-importer.processing.id-data-index: 'Dataindeks for ID-felt'
-data-importer.processing.id-data-index.tooltip: 'Kolonne brukt som stabil identifikator for Delta Check og opprydding. Disse alternativene er kun tilgjengelige når en ID-dataindeks er satt.'
-data-importer.processing.id-data-index-placeholder: 'Velg kolonne'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Opprydding'
-data-importer.processing.cleanup.do-cleanup: 'Rydd opp elementer som ikke ble importert'
-data-importer.processing.cleanup.strategy: 'Oppryddingsstrategi'
-data-importer.processing.cleanup.strategy.tooltip: 'Bestemmer hva som skjer med eksisterende elementer som ikke finnes i gjeldende import.'
-data-importer.processing.cleanup.strategy.delete: 'Slett'
-data-importer.processing.cleanup.strategy.unpublish: 'Avpubliser'
-data-importer.processing.logging.title: 'Logginnstillinger (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Deaktiver info-logger'
-data-importer.processing.logging.info.disable-file-objects: 'Deaktiver info-filobjekter'
-data-importer.processing.logging.error.title: 'Feil'
-data-importer.processing.logging.error.disable-logs: 'Deaktiver feillogger'
-data-importer.processing.logging.error.disable-file-objects: 'Deaktiver feil-filobjekter'
+data-importer.processing.title: Behandlingsinnstillinger
+data-importer.processing.execution.title: Kjøring
+data-importer.processing.id-delta.title: ID, Delta Check og opprydding
+data-importer.processing.execution-type: Kjøringstype
+data-importer.processing.execution-type.tooltip: Sekvensiell behandler ett element om gangen. Parallell behandler flere elementer samtidig.
+data-importer.processing.execution-type.sequential: Sekvensiell
+data-importer.processing.execution-type.parallel: Parallell
+data-importer.processing.archive-import-file: Arkiver importfil
+data-importer.processing.disable-versioning: Deaktiver versjonering
+data-importer.processing.id-data-index: Dataindeks for ID-felt
+data-importer.processing.id-data-index.tooltip: Kolonne brukt som stabil identifikator for Delta Check og opprydding. Disse alternativene er kun tilgjengelige når en ID-dataindeks er satt.
+data-importer.processing.id-data-index-placeholder: Velg kolonne
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Opprydding
+data-importer.processing.cleanup.do-cleanup: Rydd opp elementer som ikke ble importert
+data-importer.processing.cleanup.strategy: Oppryddingsstrategi
+data-importer.processing.cleanup.strategy.tooltip: Bestemmer hva som skjer med eksisterende elementer som ikke finnes i gjeldende import.
+data-importer.processing.cleanup.strategy.delete: Slett
+data-importer.processing.cleanup.strategy.unpublish: Avpubliser
+data-importer.processing.logging.title: Logginnstillinger (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Deaktiver info-logger
+data-importer.processing.logging.info.disable-file-objects: Deaktiver info-filobjekter
+data-importer.processing.logging.error.title: Feil
+data-importer.processing.logging.error.disable-logs: Deaktiver feillogger
+data-importer.processing.logging.error.disable-file-objects: Deaktiver feil-filobjekter
 
 # Preview Import
-data-importer.preview-import.title: 'Importforhåndsvisning'
-data-importer.preview-import.choose-preview-data: 'Velg forhåndsvisningsdata'
-data-importer.preview-import.upload-file: 'Last opp fil'
-data-importer.preview-import.copy-from-source: 'Kopier fra datakilde'
-data-importer.preview-import.search-placeholder: 'Søk etter navn, kilde, mål'
-data-importer.preview-import.column.label: 'Etikett'
-data-importer.preview-import.column.data: 'Data'
-data-importer.preview-import.prev: 'Forrige post'
-data-importer.preview-import.next: 'Neste post'
+data-importer.preview-import.title: Importforhåndsvisning
+data-importer.preview-import.choose-preview-data: Velg forhåndsvisningsdata
+data-importer.preview-import.upload-file: Last opp fil
+data-importer.preview-import.copy-from-source: Kopier fra datakilde
+data-importer.preview-import.search-placeholder: Søk etter navn, kilde, mål
+data-importer.preview-import.column.label: Etikett
+data-importer.preview-import.column.data: Data
+data-importer.preview-import.prev: Forrige post
+data-importer.preview-import.next: Neste post
 
 # Mapping
-data-importer.mapping.title: 'Mapping-konfigurasjon'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'Ny'
-data-importer.mapping.new-modal.title: 'Ny Mapping'
-data-importer.mapping.new-modal.source-label: 'Kildekolonne'
-data-importer.mapping.new-modal.source-required: 'Vennligst velg en kildekolonne'
-data-importer.mapping.collapse-all: 'Skjul alle'
-data-importer.mapping.expand-all: 'Vis alle'
-data-importer.mapping.auto-fill: 'Autoutfyll'
-data-importer.mapping.empty-state: 'Opprett en mapping direkte fra kildekolonnen, eller klikk Ny for å opprette en manuelt.'
+data-importer.mapping.title: Mapping-konfigurasjon
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: Ny
+data-importer.mapping.new-modal.title: Ny Mapping
+data-importer.mapping.new-modal.source-label: Kildekolonne
+data-importer.mapping.new-modal.source-required: Vennligst velg en kildekolonne
+data-importer.mapping.collapse-all: Skjul alle
+data-importer.mapping.expand-all: Vis alle
+data-importer.mapping.auto-fill: Autoutfyll
+data-importer.mapping.empty-state: Opprett en mapping direkte fra kildekolonnen, eller klikk Ny for å opprette en manuelt.
 data-importer.mapping.filter-empty: 'Ingen mappinger for «{{source}}» ennå.'
-data-importer.mapping.sources.title: 'Kilder med forhåndsvisning'
-data-importer.mapping.sources.reset-view: 'Tilbakestill visning'
-data-importer.mapping.sources.empty: 'Ingen forhåndsvisningsdata tilgjengelig. Konfigurer en datakilde og kjør en importforhåndsvisning først.'
-data-importer.mapping.item.new-label: 'Ny Mapping'
-data-importer.mapping.item.label: 'Etikett'
-data-importer.mapping.item.advanced: 'Avansert'
-data-importer.mapping.item.delete: 'Slett mapping'
-data-importer.mapping.item.source: 'Kilde'
-data-importer.mapping.item.source-placeholder: 'Velg kildekolonner'
-data-importer.mapping.item.destination: 'Mål'
-data-importer.mapping.item.destination-placeholder: 'Velg felt'
-data-importer.mapping.item.requires-advanced-setup: 'Krever avansert oppsett'
-data-importer.mapping.item.data-source-index: 'Datakildeindeks'
-data-importer.mapping.item.data-source-index-placeholder: 'Velg kildekolonner'
-data-importer.mapping.item.transformation-pipeline.title: 'Transformasjonspipeline'
-data-importer.mapping.item.transformation-pipeline.empty: 'Ingen transformasjonspipeline konfigurert'
-data-importer.mapping.item.transformation-result.title: 'Transformasjonsresultat'
-data-importer.mapping.item.transformation-result.type: 'Resultattype'
-data-importer.mapping.item.data-target.title: 'Datamål'
-data-importer.mapping.item.data-target.type: 'Måltype'
-data-importer.mapping.item.data-target.type-placeholder: 'Velg måltype'
-data-importer.mapping.item.data-target.type.direct: 'Direkte'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Feltnavn'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Velg felt'
-data-importer.mapping.item.data-target.language: 'Språk'
-data-importer.mapping.item.data-target.language-placeholder: 'Velg språk'
-data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Skriv hvis mål ikke er tomt'
-data-importer.mapping.item.data-target.write-if-source-is-empty: 'Skriv hvis kilde er tom'
+data-importer.mapping.sources.title: Kilder med forhåndsvisning
+data-importer.mapping.sources.reset-view: Tilbakestill visning
+data-importer.mapping.sources.empty: Ingen forhåndsvisningsdata tilgjengelig. Konfigurer en datakilde og kjør en importforhåndsvisning først.
+data-importer.mapping.item.new-label: Ny Mapping
+data-importer.mapping.item.label: Etikett
+data-importer.mapping.item.advanced: Avansert
+data-importer.mapping.item.delete: Slett mapping
+data-importer.mapping.item.source: Kilde
+data-importer.mapping.item.source-placeholder: Velg kildekolonner
+data-importer.mapping.item.destination: Mål
+data-importer.mapping.item.destination-placeholder: Velg felt
+data-importer.mapping.item.requires-advanced-setup: Krever avansert oppsett
+data-importer.mapping.item.data-source-index: Datakildeindeks
+data-importer.mapping.item.data-source-index-placeholder: Velg kildekolonner
+data-importer.mapping.item.transformation-pipeline.title: Transformasjonspipeline
+data-importer.mapping.item.transformation-pipeline.empty: Ingen transformasjonspipeline konfigurert
+data-importer.mapping.item.transformation-result.title: Transformasjonsresultat
+data-importer.mapping.item.transformation-result.type: Resultattype
+data-importer.mapping.item.data-target.title: Datamål
+data-importer.mapping.item.data-target.type: Måltype
+data-importer.mapping.item.data-target.type-placeholder: Velg måltype
+data-importer.mapping.item.data-target.type.direct: Direkte
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Feltnavn
+data-importer.mapping.item.data-target.field-name-placeholder: Velg felt
+data-importer.mapping.item.data-target.language: Språk
+data-importer.mapping.item.data-target.language-placeholder: Velg språk
+data-importer.mapping.item.data-target.write-if-target-is-not-empty: Skriv hvis mål ikke er tomt
+data-importer.mapping.item.data-target.write-if-source-is-empty: Skriv hvis kilde er tom
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Rediger mapping og transformasjoner'
-data-importer.mapping.advanced-modal.save: 'Lagre'
-data-importer.mapping.advanced-modal.step-source: 'Kilde'
-data-importer.mapping.advanced-modal.step-transformations: 'Transformasjoner'
-data-importer.mapping.advanced-modal.step-target: 'Datamål'
-data-importer.mapping.advanced-modal.no-transformers: 'Ingen transformatorer konfigurert. Legg til en nedenfor.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Legg til transformasjon'
-data-importer.mapping.advanced-modal.result-type: 'Resultattype'
-data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Skriv hvis mål ikke er tomt'
-data-importer.mapping.advanced-modal.write-if-source-empty: 'Skriv hvis kilde er tom'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Flytt opp'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Flytt ned'
-data-importer.mapping.advanced-modal.transformer.remove: 'Fjern'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Rediger kildeattributter'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Datamanipulering'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Datatyper'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Last / Importer'
-data-importer.mapping.advanced-modal.next-step: 'Neste steg'
-data-importer.mapping.advanced-modal.previous-step: 'Forrige steg'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Beregn transformasjonsresultattype på nytt'
-data-importer.mapping.advanced-modal.step-source.label: 'Kildeattributt(er)'
-data-importer.mapping.advanced-modal.step-source.description: 'Velg fra listen eller legg til en ny kilde'
-data-importer.mapping.advanced-modal.step-source.import-preview: 'Importforhåndsvisning'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Søk'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Navn'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Data'
-data-importer.mapping.advanced-modal.loading: 'Laster…'
-data-importer.mapping.advanced-modal.no-data: 'Ingen data'
-data-importer.mapping.advanced-modal.no-preview: 'Ingen forhåndsvisning tilgjengelig'
-data-importer.mapping.advanced-modal.step-target.type: 'Type'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Feltnavn'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Overskriv'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Forhåndsvisningsresultat'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Forrige steg'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Bekreft mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Skriv til dette feltet selv om målfeltet allerede inneholder en verdi'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Skriv til dette feltet selv om kildedataene er tomme'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Overskrivningsmodus'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Erstatt'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Slå sammen'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'Ingen nøkkel valgt'
+data-importer.mapping.advanced-modal.title: Rediger mapping og transformasjoner
+data-importer.mapping.advanced-modal.save: Lagre
+data-importer.mapping.advanced-modal.step-source: Kilde
+data-importer.mapping.advanced-modal.step-transformations: Transformasjoner
+data-importer.mapping.advanced-modal.step-target: Datamål
+data-importer.mapping.advanced-modal.no-transformers: Ingen transformatorer konfigurert. Legg til en nedenfor.
+data-importer.mapping.advanced-modal.add-transformation: + Legg til transformasjon
+data-importer.mapping.advanced-modal.result-type: Resultattype
+data-importer.mapping.advanced-modal.write-if-target-not-empty: Skriv hvis mål ikke er tomt
+data-importer.mapping.advanced-modal.write-if-source-empty: Skriv hvis kilde er tom
+data-importer.mapping.advanced-modal.transformer.move-up: Flytt opp
+data-importer.mapping.advanced-modal.transformer.move-down: Flytt ned
+data-importer.mapping.advanced-modal.transformer.remove: Fjern
+data-importer.mapping.advanced-modal.transformer.edit-source: Rediger kildeattributter
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Datamanipulering
+data-importer.mapping.advanced-modal.transformer.group.data-types: Datatyper
+data-importer.mapping.advanced-modal.transformer.group.load-import: Last / Importer
+data-importer.mapping.advanced-modal.next-step: Neste steg
+data-importer.mapping.advanced-modal.previous-step: Forrige steg
+data-importer.mapping.advanced-modal.recalculate-result-type: Beregn transformasjonsresultattype på nytt
+data-importer.mapping.advanced-modal.step-source.label: Kildeattributt(er)
+data-importer.mapping.advanced-modal.step-source.description: Velg fra listen eller legg til en ny kilde
+data-importer.mapping.advanced-modal.step-source.import-preview: Importforhåndsvisning
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Søk
+data-importer.mapping.advanced-modal.step-source.column-name: Navn
+data-importer.mapping.advanced-modal.step-source.column-data: Data
+data-importer.mapping.advanced-modal.loading: Laster…
+data-importer.mapping.advanced-modal.no-data: Ingen data
+data-importer.mapping.advanced-modal.no-preview: Ingen forhåndsvisning tilgjengelig
+data-importer.mapping.advanced-modal.step-target.type: Type
+data-importer.mapping.advanced-modal.step-target.field-name: Feltnavn
+data-importer.mapping.advanced-modal.step-target.overwrite: Overskriv
+data-importer.mapping.advanced-modal.step-target.preview-result: Forhåndsvisningsresultat
+data-importer.mapping.advanced-modal.step-target.previous-step: Forrige steg
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Bekreft mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Skriv til dette feltet selv om målfeltet allerede inneholder en verdi
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Skriv til dette feltet selv om kildedataene er tomme
+data-importer.mapping.advanced-modal.step-target.overwrite-mode: Overskrivningsmodus
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Erstatt
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Slå sammen
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: Ingen nøkkel valgt
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} i gruppe {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Velg Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Søk og velg en nøkkel for dette Classification Store-feltet'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Velg Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Søk og velg en nøkkel for dette Classification Store-feltet
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch krever transformasjonsresultattype: array, quantityValueArray, inputQuantityValueArray eller dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation krever transformasjonsresultattype: advancedDataObject, dataObjectArray, assetArray eller advancedAssetArray.'
 
-error.error_environment: 'Forhåndsvisningsfilen er ikke gyldig for den konfigurerte tolken. Vennligst last opp eller kopier forhåndsvisningsdataene på nytt.'
+error.error_environment: Forhåndsvisningsfilen er ikke gyldig for den konfigurerte tolken. Vennligst last opp eller kopier forhåndsvisningsdataene på nytt.
 
 # Execution Tab
-data-importer.execution.settings.title: 'Kjøringsinnstillinger'
-data-importer.execution.schedule-type: 'Tidsplantype'
-data-importer.execution.schedule-type.recurring: 'Gjentakende / Cron'
-data-importer.execution.schedule-type.job: 'Engangsjobb'
-data-importer.execution.cron-definition: 'Cron-definisjon'
-data-importer.execution.cron-generator: 'Cron-generator'
-data-importer.execution.scheduled-at: 'Planlagt til'
-data-importer.execution.manual-execution: 'Manuell kjøring'
-data-importer.execution.start-import: 'Start import'
-data-importer.execution.start-import.success: 'Importen ble startet'
-data-importer.execution.start-import.error: 'Kunne ikke starte importen'
-data-importer.execution.start-import.tooltip-dirty: 'Lagre endringene dine før du starter importen'
-data-importer.execution.start-import.tooltip-push: 'Push-laster støtter ikke manuell kjøring'
-data-importer.execution.cancel.success: 'Importen ble avbrutt'
-data-importer.execution.cancel.error: 'Kunne ikke avbryte importen'
-data-importer.execution.status.title: 'Kjøringsstatus'
-data-importer.execution.status.not-running: 'Kjører ikke'
-data-importer.execution.status.finished: 'Alle elementer behandlet. Ingen import kjører.'
-data-importer.execution.status.current-progress: 'Gjeldende fremdrift'
+data-importer.execution.settings.title: Kjøringsinnstillinger
+data-importer.execution.schedule-type: Tidsplantype
+data-importer.execution.schedule-type.recurring: Gjentakende / Cron
+data-importer.execution.schedule-type.job: Engangsjobb
+data-importer.execution.cron-definition: Cron-definisjon
+data-importer.execution.cron-generator: Cron-generator
+data-importer.execution.scheduled-at: Planlagt til
+data-importer.execution.manual-execution: Manuell kjøring
+data-importer.execution.start-import: Start import
+data-importer.execution.start-import.success: Importen ble startet
+data-importer.execution.start-import.error: Kunne ikke starte importen
+data-importer.execution.start-import.tooltip-dirty: Lagre endringene dine før du starter importen
+data-importer.execution.start-import.tooltip-push: Push-laster støtter ikke manuell kjøring
+data-importer.execution.cancel.success: Importen ble avbrutt
+data-importer.execution.cancel.error: Kunne ikke avbryte importen
+data-importer.execution.status.title: Kjøringsstatus
+data-importer.execution.status.not-running: Kjører ikke
+data-importer.execution.status.finished: Alle elementer behandlet. Ingen import kjører.
+data-importer.execution.status.current-progress: Gjeldende fremdrift
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} elementer behandlet...'
-data-importer.execution.status.cancel: 'Avbryt kjøring og tøm kø'
-data-importer.execution.cron-validating: 'Validerer Cron-uttrykk...'
+data-importer.execution.status.cancel: Avbryt kjøring og tøm kø
+data-importer.execution.cron-validating: Validerer Cron-uttrykk...
 data-importer.validation.required: '{{field}} er påkrevd'

--- a/src/Resources/translations/studio.sv.yaml
+++ b/src/Resources/translations/studio.sv.yaml
@@ -1,316 +1,316 @@
-data-importer.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-hub.adapter.dataImporterDataObject: 'Data Importer - Data Objects'
-data-importer.tabs.general: 'Allmänt'
-data-importer.tabs.permissions: 'Behörigheter'
-data-importer.tabs.data-setup: 'Datainställning'
-data-importer.tabs.import-logs: 'Importloggar'
-data-importer.tabs.execution: 'Körning'
+data-importer.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-hub.adapter.dataImporterDataObject: Data Importer - Data Objects
+data-importer.tabs.general: Allmänt
+data-importer.tabs.permissions: Behörigheter
+data-importer.tabs.data-setup: Datainställning
+data-importer.tabs.import-logs: Importloggar
+data-importer.tabs.execution: Körning
 
 # Data Setup Steps
-data-importer.data-setup.steps.data-source.title: 'Datakälla'
-data-importer.data-setup.steps.data-source.description: 'Konfigurera datakälla och filformat'
-data-importer.data-setup.steps.preview-import.title: 'Importförhandsvisning'
-data-importer.data-setup.steps.preview-import.description: 'Förhandsgranska data som ska importeras'
-data-importer.data-setup.steps.resolver.title: 'Resolver'
-data-importer.data-setup.steps.resolver.description: 'Konfigurera regler för dataupplösning'
-data-importer.data-setup.steps.mapping.title: 'Mapping'
-data-importer.data-setup.steps.mapping.description: 'Mappa källfält till målfält'
-data-importer.data-setup.steps.processing-settings.title: 'Bearbetningsinställningar'
-data-importer.data-setup.steps.processing-settings.description: 'Konfigurera bearbetningsinställningar för import'
+data-importer.data-setup.steps.data-source.title: Datakälla
+data-importer.data-setup.steps.data-source.description: Konfigurera datakälla och filformat
+data-importer.data-setup.steps.preview-import.title: Importförhandsvisning
+data-importer.data-setup.steps.preview-import.description: Förhandsgranska data som ska importeras
+data-importer.data-setup.steps.resolver.title: Resolver
+data-importer.data-setup.steps.resolver.description: Konfigurera regler för dataupplösning
+data-importer.data-setup.steps.mapping.title: Mapping
+data-importer.data-setup.steps.mapping.description: Mappa källfält till målfält
+data-importer.data-setup.steps.processing-settings.title: Bearbetningsinställningar
+data-importer.data-setup.steps.processing-settings.description: Konfigurera bearbetningsinställningar för import
 
 # Data Source
-data-importer.data-source.title: 'Datakälla'
-data-importer.data-source.type: 'Typ'
-data-importer.data-source.type-label: 'Datakälletyp'
+data-importer.data-source.title: Datakälla
+data-importer.data-source.type: Typ
+data-importer.data-source.type-label: Datakälletyp
 
 # Loaders
-data-importer.loader.asset: 'Asset'
-data-importer.loader.upload: 'Upload'
-data-importer.loader.http: 'HTTP'
-data-importer.loader.sftp: 'SFTP'
-data-importer.loader.push: 'Push'
-data-importer.loader.sql: 'SQL'
+data-importer.loader.asset: Asset
+data-importer.loader.upload: Upload
+data-importer.loader.http: HTTP
+data-importer.loader.sftp: SFTP
+data-importer.loader.push: Push
+data-importer.loader.sql: SQL
 
 # Asset Loader
-data-importer.loader.asset.asset-path: 'Asset-sökväg'
+data-importer.loader.asset.asset-path: Asset-sökväg
 
 # Upload Loader
-data-importer.loader.upload.status: 'Upload-status'
-data-importer.loader.upload.file-uploaded: 'Filen har laddats upp'
-data-importer.loader.upload.no-file: 'Ingen fil uppladdad ännu'
-data-importer.loader.upload.file-path: 'Sökväg för uppladdad fil'
-data-importer.loader.upload.open-upload: 'Ladda upp fil'
-data-importer.loader.upload.modal-title: 'Ladda upp importfil'
+data-importer.loader.upload.status: Upload-status
+data-importer.loader.upload.file-uploaded: Filen har laddats upp
+data-importer.loader.upload.no-file: Ingen fil uppladdad ännu
+data-importer.loader.upload.file-path: Sökväg för uppladdad fil
+data-importer.loader.upload.open-upload: Ladda upp fil
+data-importer.loader.upload.modal-title: Ladda upp importfil
 
 # HTTP Loader
-data-importer.loader.http.schema: 'Schema'
-data-importer.loader.http.url: 'URL'
+data-importer.loader.http.schema: Schema
+data-importer.loader.http.url: URL
 
 # SFTP Loader
-data-importer.loader.sftp.host: 'Host'
-data-importer.loader.sftp.port: 'Port'
-data-importer.loader.sftp.username: 'Användarnamn'
-data-importer.loader.sftp.password: 'Lösenord'
-data-importer.loader.sftp.remote-path: 'Fjärrsökväg'
+data-importer.loader.sftp.host: Host
+data-importer.loader.sftp.port: Port
+data-importer.loader.sftp.username: Användarnamn
+data-importer.loader.sftp.password: Lösenord
+data-importer.loader.sftp.remote-path: Fjärrsökväg
 
 # Push Loader
-data-importer.loader.push.api-key: 'API Key'
-data-importer.loader.push.api-key.generate: 'Generera API Key'
-data-importer.loader.push.api-key-required: 'Ange en API Key'
-data-importer.loader.push.api-key-min-length: 'API Key måste vara minst 16 tecken lång'
-data-importer.loader.push.ignore-not-empty-queue: 'Ignorera icke-tom kö'
-data-importer.loader.push.endpoint: 'Endpoint'
+data-importer.loader.push.api-key: API Key
+data-importer.loader.push.api-key.generate: Generera API Key
+data-importer.loader.push.api-key-required: Ange en API Key
+data-importer.loader.push.api-key-min-length: API Key måste vara minst 16 tecken lång
+data-importer.loader.push.ignore-not-empty-queue: Ignorera icke-tom kö
+data-importer.loader.push.endpoint: Endpoint
 
 # SQL Loader
-data-importer.loader.sql.connection: 'Databasanslutning'
-data-importer.loader.sql.select: 'SELECT'
-data-importer.loader.sql.from: 'FROM'
-data-importer.loader.sql.where: 'WHERE'
-data-importer.loader.sql.group-by: 'GROUP BY'
+data-importer.loader.sql.connection: Databasanslutning
+data-importer.loader.sql.select: SELECT
+data-importer.loader.sql.from: FROM
+data-importer.loader.sql.where: WHERE
+data-importer.loader.sql.group-by: GROUP BY
 
 # File Format
-data-importer.file-format.title: 'Filformat'
-data-importer.file-format.type: 'Typ'
+data-importer.file-format.title: Filformat
+data-importer.file-format.type: Typ
 
 # Interpreters
-data-importer.interpreter.csv: 'CSV'
-data-importer.interpreter.json: 'JSON'
-data-importer.interpreter.xml: 'XML'
-data-importer.interpreter.xlsx: 'XLSX'
-data-importer.interpreter.sql: 'SQL'
+data-importer.interpreter.csv: CSV
+data-importer.interpreter.json: JSON
+data-importer.interpreter.xml: XML
+data-importer.interpreter.xlsx: XLSX
+data-importer.interpreter.sql: SQL
 
 # CSV Interpreter
-data-importer.interpreter.csv.delimiter: 'Avgränsare'
-data-importer.interpreter.csv.enclosure: 'Textavgränsare'
-data-importer.interpreter.csv.escape: 'Escape-tecken'
+data-importer.interpreter.csv.delimiter: Avgränsare
+data-importer.interpreter.csv.enclosure: Textavgränsare
+data-importer.interpreter.csv.escape: Escape-tecken
 data-importer.interpreter.csv.required: '{{field}} är obligatoriskt'
 data-importer.interpreter.csv.single-char-only: '{{field}} måste vara tomt eller ett enskilt tecken'
-data-importer.interpreter.csv.skip-first-row: 'Hoppa över första raden'
-data-importer.interpreter.csv.save-header-name: 'Spara rubriknamn'
+data-importer.interpreter.csv.skip-first-row: Hoppa över första raden
+data-importer.interpreter.csv.save-header-name: Spara rubriknamn
 
 # JSON Interpreter
-data-importer.interpreter.json.path: 'Sökväg'
+data-importer.interpreter.json.path: Sökväg
 
 # XML Interpreter
-data-importer.interpreter.xml.xpath: 'XPath'
-data-importer.interpreter.xml.schema: 'Schema'
+data-importer.interpreter.xml.xpath: XPath
+data-importer.interpreter.xml.schema: Schema
 
 # XLSX Interpreter
-data-importer.interpreter.xlsx.sheet-name: 'Bladnamn'
-data-importer.interpreter.xlsx.skip-first-row: 'Hoppa över första raden'
+data-importer.interpreter.xlsx.sheet-name: Bladnamn
+data-importer.interpreter.xlsx.skip-first-row: Hoppa över första raden
 
 # SQL Interpreter
-data-importer.interpreter.sql.info: 'SQL-tolken använder frågekonfigurationen från SQL-laddaren.'
+data-importer.interpreter.sql.info: SQL-tolken använder frågekonfigurationen från SQL-laddaren.
 
 # Resolver
-data-importer.resolver.title: 'Resolver'
-data-importer.resolver.class: 'Data Object-klass'
-data-importer.resolver.class-placeholder: 'Välj klass'
-data-importer.resolver.element-loading: 'Elementladdning'
-data-importer.resolver.loading-strategy: 'Laddningsstrategi'
-data-importer.resolver.loading-strategy.tooltip: 'Definierar hur befintliga element matchas före import. Om inget element hittas tillämpas skapanderegler.'
-data-importer.resolver.loading-strategy.notLoad: 'Ingen laddning'
-data-importer.resolver.loading-strategy.id: 'Id'
-data-importer.resolver.loading-strategy.path: 'Sökväg'
-data-importer.resolver.loading-strategy.attribute: 'Attribut'
-data-importer.resolver.loading-strategy.attribute-name: 'Attributnamn'
-data-importer.resolver.loading-strategy.attribute-name-placeholder: 'Välj attribut'
-data-importer.resolver.loading-strategy.data-source-index: 'Datakälleindex'
-data-importer.resolver.loading-strategy.data-source-index-placeholder: 'Välj kolumn'
-data-importer.resolver.loading-strategy.language: 'Språk'
-data-importer.resolver.loading-strategy.language-placeholder: 'Välj språk'
-data-importer.resolver.loading-strategy.include-unpublished: 'Inkludera opublicerade objekt'
-data-importer.resolver.element-creation: 'Elementskapande'
-data-importer.resolver.create-location-strategy: 'Platsstrategi'
-data-importer.resolver.create-location-strategy.tooltip: 'Styr var nyskapade element placeras när inget befintligt element kunde hittas.'
-data-importer.resolver.location-strategy.staticPath: 'Statisk sökväg'
-data-importer.resolver.location-strategy.findOrCreateFolder: 'Hitta eller skapa mapp'
-data-importer.resolver.location-strategy.findParent: 'Hitta överordnat element'
-data-importer.resolver.location-strategy.doNotCreate: 'Skapa inte'
-data-importer.resolver.location-strategy.noChange: 'Ingen ändring'
-data-importer.resolver.location-strategy.path: 'Sökväg'
-data-importer.resolver.location-strategy.path-placeholder: 'Ange sökväg'
-data-importer.resolver.location-strategy.data-source-index: 'Datakälleindex'
-data-importer.resolver.location-strategy.data-source-index-placeholder: 'Välj kolumn'
-data-importer.resolver.location-strategy.fallback-path: 'Reservsökväg'
-data-importer.resolver.location-strategy.fallback-path.tooltip: 'Används när en dynamisk målplats inte kan bestämmas från källdata.'
-data-importer.resolver.location-strategy.fallback-path-placeholder: 'Ange reservsökväg'
-data-importer.resolver.location-strategy.find-strategy: 'Sökstrategi'
-data-importer.resolver.location-strategy.find-strategy.id: 'Via ID'
-data-importer.resolver.location-strategy.find-strategy.path: 'Via sökväg'
-data-importer.resolver.location-strategy.find-strategy.attribute: 'Via attribut'
-data-importer.resolver.location-strategy.attribute-class: 'Klass'
-data-importer.resolver.location-strategy.attribute-name: 'Attributnamn'
-data-importer.resolver.location-strategy.attribute-language: 'Språk'
-data-importer.resolver.location-strategy.as-variant: 'Som variant'
-data-importer.resolver.element-location-update: 'Uppdatering av elementplats'
-data-importer.resolver.location-update-strategy: 'Platsstrategi'
-data-importer.resolver.location-update-strategy.tooltip: 'Styr om och hur platsen för redan matchade element ändras vid import.'
-data-importer.resolver.element-publishing: 'Elementpublicering'
-data-importer.resolver.publishing-strategy: 'Publiceringsstrategi'
-data-importer.resolver.publishing-strategy.tooltip: 'Definierar publicerings- eller avpubliceringsbeteende för importerade element.'
-data-importer.resolver.publishing-strategy.noChangeUnpublishNew: 'Ingen ändring / Avpublicera nya'
-data-importer.resolver.publishing-strategy.noChangePublishNew: 'Ingen ändring / Publicera nya'
-data-importer.resolver.publishing-strategy.alwaysPublish: 'Publicera alltid'
-data-importer.resolver.publishing-strategy.attributeBased: 'Attributbaserad'
-data-importer.resolver.publishing-strategy.data-source-index: 'Datakälleindex'
-data-importer.resolver.publishing-strategy.data-source-index-placeholder: 'Välj kolumn'
+data-importer.resolver.title: Resolver
+data-importer.resolver.class: Data Object-klass
+data-importer.resolver.class-placeholder: Välj klass
+data-importer.resolver.element-loading: Elementladdning
+data-importer.resolver.loading-strategy: Laddningsstrategi
+data-importer.resolver.loading-strategy.tooltip: Definierar hur befintliga element matchas före import. Om inget element hittas tillämpas skapanderegler.
+data-importer.resolver.loading-strategy.notLoad: Ingen laddning
+data-importer.resolver.loading-strategy.id: Id
+data-importer.resolver.loading-strategy.path: Sökväg
+data-importer.resolver.loading-strategy.attribute: Attribut
+data-importer.resolver.loading-strategy.attribute-name: Attributnamn
+data-importer.resolver.loading-strategy.attribute-name-placeholder: Välj attribut
+data-importer.resolver.loading-strategy.data-source-index: Datakälleindex
+data-importer.resolver.loading-strategy.data-source-index-placeholder: Välj kolumn
+data-importer.resolver.loading-strategy.language: Språk
+data-importer.resolver.loading-strategy.language-placeholder: Välj språk
+data-importer.resolver.loading-strategy.include-unpublished: Inkludera opublicerade objekt
+data-importer.resolver.element-creation: Elementskapande
+data-importer.resolver.create-location-strategy: Platsstrategi
+data-importer.resolver.create-location-strategy.tooltip: Styr var nyskapade element placeras när inget befintligt element kunde hittas.
+data-importer.resolver.location-strategy.staticPath: Statisk sökväg
+data-importer.resolver.location-strategy.findOrCreateFolder: Hitta eller skapa mapp
+data-importer.resolver.location-strategy.findParent: Hitta överordnat element
+data-importer.resolver.location-strategy.doNotCreate: Skapa inte
+data-importer.resolver.location-strategy.noChange: Ingen ändring
+data-importer.resolver.location-strategy.path: Sökväg
+data-importer.resolver.location-strategy.path-placeholder: Ange sökväg
+data-importer.resolver.location-strategy.data-source-index: Datakälleindex
+data-importer.resolver.location-strategy.data-source-index-placeholder: Välj kolumn
+data-importer.resolver.location-strategy.fallback-path: Reservsökväg
+data-importer.resolver.location-strategy.fallback-path.tooltip: Används när en dynamisk målplats inte kan bestämmas från källdata.
+data-importer.resolver.location-strategy.fallback-path-placeholder: Ange reservsökväg
+data-importer.resolver.location-strategy.find-strategy: Sökstrategi
+data-importer.resolver.location-strategy.find-strategy.id: Via ID
+data-importer.resolver.location-strategy.find-strategy.path: Via sökväg
+data-importer.resolver.location-strategy.find-strategy.attribute: Via attribut
+data-importer.resolver.location-strategy.attribute-class: Klass
+data-importer.resolver.location-strategy.attribute-name: Attributnamn
+data-importer.resolver.location-strategy.attribute-language: Språk
+data-importer.resolver.location-strategy.as-variant: Som variant
+data-importer.resolver.element-location-update: Uppdatering av elementplats
+data-importer.resolver.location-update-strategy: Platsstrategi
+data-importer.resolver.location-update-strategy.tooltip: Styr om och hur platsen för redan matchade element ändras vid import.
+data-importer.resolver.element-publishing: Elementpublicering
+data-importer.resolver.publishing-strategy: Publiceringsstrategi
+data-importer.resolver.publishing-strategy.tooltip: Definierar publicerings- eller avpubliceringsbeteende för importerade element.
+data-importer.resolver.publishing-strategy.noChangeUnpublishNew: Ingen ändring / Avpublicera nya
+data-importer.resolver.publishing-strategy.noChangePublishNew: Ingen ändring / Publicera nya
+data-importer.resolver.publishing-strategy.alwaysPublish: Publicera alltid
+data-importer.resolver.publishing-strategy.attributeBased: Attributbaserad
+data-importer.resolver.publishing-strategy.data-source-index: Datakälleindex
+data-importer.resolver.publishing-strategy.data-source-index-placeholder: Välj kolumn
 
 # Processing Settings
-data-importer.processing.title: 'Bearbetningsinställningar'
-data-importer.processing.execution.title: 'Körning'
-data-importer.processing.id-delta.title: 'ID, Delta Check & rensning'
-data-importer.processing.execution-type: 'Körningstyp'
-data-importer.processing.execution-type.tooltip: 'Sekventiell kör ett objekt i taget. Parallell bearbetar flera objekt samtidigt.'
-data-importer.processing.execution-type.sequential: 'Sekventiell'
-data-importer.processing.execution-type.parallel: 'Parallell'
-data-importer.processing.archive-import-file: 'Arkivera importfil'
-data-importer.processing.disable-versioning: 'Inaktivera versionshantering'
-data-importer.processing.id-data-index: 'Dataindex för ID-fält'
-data-importer.processing.id-data-index.tooltip: 'Kolumn som används som stabil identifierare för Delta Check och rensning. Dessa alternativ är bara tillgängliga när ett ID-dataindex har angetts.'
-data-importer.processing.id-data-index-placeholder: 'Välj kolumn'
-data-importer.processing.delta-check: 'Delta Check'
-data-importer.processing.cleanup.title: 'Rensning'
-data-importer.processing.cleanup.do-cleanup: 'Rensa ej importerade element'
-data-importer.processing.cleanup.strategy: 'Rensningsstrategi'
-data-importer.processing.cleanup.strategy.tooltip: 'Avgör vad som händer med befintliga element som inte finns med i den aktuella importen.'
-data-importer.processing.cleanup.strategy.delete: 'Ta bort'
-data-importer.processing.cleanup.strategy.unpublish: 'Avpublicera'
-data-importer.processing.logging.title: 'Loggningsinställningar (Application Logger)'
-data-importer.processing.logging.info.title: 'Info'
-data-importer.processing.logging.info.disable-logs: 'Inaktivera infologgar'
-data-importer.processing.logging.info.disable-file-objects: 'Inaktivera info-filobjekt'
-data-importer.processing.logging.error.title: 'Fel'
-data-importer.processing.logging.error.disable-logs: 'Inaktivera felloggar'
-data-importer.processing.logging.error.disable-file-objects: 'Inaktivera fel-filobjekt'
+data-importer.processing.title: Bearbetningsinställningar
+data-importer.processing.execution.title: Körning
+data-importer.processing.id-delta.title: ID, Delta Check & rensning
+data-importer.processing.execution-type: Körningstyp
+data-importer.processing.execution-type.tooltip: Sekventiell kör ett objekt i taget. Parallell bearbetar flera objekt samtidigt.
+data-importer.processing.execution-type.sequential: Sekventiell
+data-importer.processing.execution-type.parallel: Parallell
+data-importer.processing.archive-import-file: Arkivera importfil
+data-importer.processing.disable-versioning: Inaktivera versionshantering
+data-importer.processing.id-data-index: Dataindex för ID-fält
+data-importer.processing.id-data-index.tooltip: Kolumn som används som stabil identifierare för Delta Check och rensning. Dessa alternativ är bara tillgängliga när ett ID-dataindex har angetts.
+data-importer.processing.id-data-index-placeholder: Välj kolumn
+data-importer.processing.delta-check: Delta Check
+data-importer.processing.cleanup.title: Rensning
+data-importer.processing.cleanup.do-cleanup: Rensa ej importerade element
+data-importer.processing.cleanup.strategy: Rensningsstrategi
+data-importer.processing.cleanup.strategy.tooltip: Avgör vad som händer med befintliga element som inte finns med i den aktuella importen.
+data-importer.processing.cleanup.strategy.delete: Ta bort
+data-importer.processing.cleanup.strategy.unpublish: Avpublicera
+data-importer.processing.logging.title: Loggningsinställningar (Application Logger)
+data-importer.processing.logging.info.title: Info
+data-importer.processing.logging.info.disable-logs: Inaktivera infologgar
+data-importer.processing.logging.info.disable-file-objects: Inaktivera info-filobjekt
+data-importer.processing.logging.error.title: Fel
+data-importer.processing.logging.error.disable-logs: Inaktivera felloggar
+data-importer.processing.logging.error.disable-file-objects: Inaktivera fel-filobjekt
 
 # Preview Import
-data-importer.preview-import.title: 'Importförhandsvisning'
-data-importer.preview-import.choose-preview-data: 'Välj förhandsvisningsdata'
-data-importer.preview-import.upload-file: 'Ladda upp fil'
-data-importer.preview-import.copy-from-source: 'Kopiera från datakälla'
-data-importer.preview-import.search-placeholder: 'Sök efter namn, källa, mål'
-data-importer.preview-import.column.label: 'Etikett'
-data-importer.preview-import.column.data: 'Data'
-data-importer.preview-import.prev: 'Föregående post'
-data-importer.preview-import.next: 'Nästa post'
+data-importer.preview-import.title: Importförhandsvisning
+data-importer.preview-import.choose-preview-data: Välj förhandsvisningsdata
+data-importer.preview-import.upload-file: Ladda upp fil
+data-importer.preview-import.copy-from-source: Kopiera från datakälla
+data-importer.preview-import.search-placeholder: Sök efter namn, källa, mål
+data-importer.preview-import.column.label: Etikett
+data-importer.preview-import.column.data: Data
+data-importer.preview-import.prev: Föregående post
+data-importer.preview-import.next: Nästa post
 
 # Mapping
-data-importer.mapping.title: 'Mapping-konfiguration'
-data-importer.mapping.title-short: 'Mappings'
-data-importer.mapping.add: 'Ny'
-data-importer.mapping.new-modal.title: 'Ny Mapping'
-data-importer.mapping.new-modal.source-label: 'Källkolumn'
-data-importer.mapping.new-modal.source-required: 'Välj en källkolumn'
-data-importer.mapping.collapse-all: 'Fäll ihop alla'
-data-importer.mapping.expand-all: 'Expandera alla'
-data-importer.mapping.auto-fill: 'Autofyll'
-data-importer.mapping.empty-state: 'Skapa en mapping direkt från kolumnen Källor, eller klicka på Ny för att skapa en manuellt.'
+data-importer.mapping.title: Mapping-konfiguration
+data-importer.mapping.title-short: Mappings
+data-importer.mapping.add: Ny
+data-importer.mapping.new-modal.title: Ny Mapping
+data-importer.mapping.new-modal.source-label: Källkolumn
+data-importer.mapping.new-modal.source-required: Välj en källkolumn
+data-importer.mapping.collapse-all: Fäll ihop alla
+data-importer.mapping.expand-all: Expandera alla
+data-importer.mapping.auto-fill: Autofyll
+data-importer.mapping.empty-state: Skapa en mapping direkt från kolumnen Källor, eller klicka på Ny för att skapa en manuellt.
 data-importer.mapping.filter-empty: 'Inga mappings för "{{source}}" ännu.'
-data-importer.mapping.sources.title: 'Källor med förhandsvisning'
-data-importer.mapping.sources.reset-view: 'Återställ vy'
-data-importer.mapping.sources.empty: 'Ingen förhandsvisningsdata tillgänglig. Konfigurera en datakälla och kör en importförhandsvisning först.'
-data-importer.mapping.item.new-label: 'Ny Mapping'
-data-importer.mapping.item.label: 'Etikett'
-data-importer.mapping.item.advanced: 'Avancerat'
-data-importer.mapping.item.delete: 'Ta bort mapping'
-data-importer.mapping.item.source: 'Källa'
-data-importer.mapping.item.source-placeholder: 'Välj källkolumner'
-data-importer.mapping.item.destination: 'Mål'
-data-importer.mapping.item.destination-placeholder: 'Välj fält'
-data-importer.mapping.item.requires-advanced-setup: 'Kräver avancerad konfiguration'
-data-importer.mapping.item.data-source-index: 'Datakälleindex'
-data-importer.mapping.item.data-source-index-placeholder: 'Välj källkolumner'
-data-importer.mapping.item.transformation-pipeline.title: 'Transformationspipeline'
-data-importer.mapping.item.transformation-pipeline.empty: 'Ingen Transformationspipeline konfigurerad'
-data-importer.mapping.item.transformation-result.title: 'Transformationsresultat'
-data-importer.mapping.item.transformation-result.type: 'Resultattyp'
-data-importer.mapping.item.data-target.title: 'Datamål'
-data-importer.mapping.item.data-target.type: 'Måltyp'
-data-importer.mapping.item.data-target.type-placeholder: 'Välj måltyp'
-data-importer.mapping.item.data-target.type.direct: 'Direkt'
-data-importer.mapping.item.data-target.type.classificationstore: 'Classification Store'
-data-importer.mapping.item.data-target.type.classificationstoreBatch: 'Classification Store Batch'
-data-importer.mapping.item.data-target.type.manyToManyRelation: 'Many-to-Many Relation'
-data-importer.mapping.item.data-target.field-name: 'Fältnamn'
-data-importer.mapping.item.data-target.field-name-placeholder: 'Välj fält'
-data-importer.mapping.item.data-target.language: 'Språk'
-data-importer.mapping.item.data-target.language-placeholder: 'Välj språk'
-data-importer.mapping.item.data-target.write-if-target-is-not-empty: 'Skriv om målet inte är tomt'
-data-importer.mapping.item.data-target.write-if-source-is-empty: 'Skriv om källan är tom'
+data-importer.mapping.sources.title: Källor med förhandsvisning
+data-importer.mapping.sources.reset-view: Återställ vy
+data-importer.mapping.sources.empty: Ingen förhandsvisningsdata tillgänglig. Konfigurera en datakälla och kör en importförhandsvisning först.
+data-importer.mapping.item.new-label: Ny Mapping
+data-importer.mapping.item.label: Etikett
+data-importer.mapping.item.advanced: Avancerat
+data-importer.mapping.item.delete: Ta bort mapping
+data-importer.mapping.item.source: Källa
+data-importer.mapping.item.source-placeholder: Välj källkolumner
+data-importer.mapping.item.destination: Mål
+data-importer.mapping.item.destination-placeholder: Välj fält
+data-importer.mapping.item.requires-advanced-setup: Kräver avancerad konfiguration
+data-importer.mapping.item.data-source-index: Datakälleindex
+data-importer.mapping.item.data-source-index-placeholder: Välj källkolumner
+data-importer.mapping.item.transformation-pipeline.title: Transformationspipeline
+data-importer.mapping.item.transformation-pipeline.empty: Ingen Transformationspipeline konfigurerad
+data-importer.mapping.item.transformation-result.title: Transformationsresultat
+data-importer.mapping.item.transformation-result.type: Resultattyp
+data-importer.mapping.item.data-target.title: Datamål
+data-importer.mapping.item.data-target.type: Måltyp
+data-importer.mapping.item.data-target.type-placeholder: Välj måltyp
+data-importer.mapping.item.data-target.type.direct: Direkt
+data-importer.mapping.item.data-target.type.classificationstore: Classification Store
+data-importer.mapping.item.data-target.type.classificationstoreBatch: Classification Store Batch
+data-importer.mapping.item.data-target.type.manyToManyRelation: Many-to-Many Relation
+data-importer.mapping.item.data-target.field-name: Fältnamn
+data-importer.mapping.item.data-target.field-name-placeholder: Välj fält
+data-importer.mapping.item.data-target.language: Språk
+data-importer.mapping.item.data-target.language-placeholder: Välj språk
+data-importer.mapping.item.data-target.write-if-target-is-not-empty: Skriv om målet inte är tomt
+data-importer.mapping.item.data-target.write-if-source-is-empty: Skriv om källan är tom
 
 # Advanced Mapping Modal
-data-importer.mapping.advanced-modal.title: 'Redigera mapping & transformationer'
-data-importer.mapping.advanced-modal.save: 'Spara'
-data-importer.mapping.advanced-modal.step-source: 'Källa'
-data-importer.mapping.advanced-modal.step-transformations: 'Transformationer'
-data-importer.mapping.advanced-modal.step-target: 'Datamål'
-data-importer.mapping.advanced-modal.no-transformers: 'Inga transformatorer konfigurerade. Lägg till en nedan.'
-data-importer.mapping.advanced-modal.add-transformation: '+ Lägg till transformation'
-data-importer.mapping.advanced-modal.result-type: 'Resultattyp'
-data-importer.mapping.advanced-modal.write-if-target-not-empty: 'Skriv om målet inte är tomt'
-data-importer.mapping.advanced-modal.write-if-source-empty: 'Skriv om källan är tom'
-data-importer.mapping.advanced-modal.transformer.move-up: 'Flytta upp'
-data-importer.mapping.advanced-modal.transformer.move-down: 'Flytta ner'
-data-importer.mapping.advanced-modal.transformer.remove: 'Ta bort'
-data-importer.mapping.advanced-modal.transformer.edit-source: 'Redigera källattribut'
-data-importer.mapping.advanced-modal.transformer.group.data-manipulation: 'Datamanipulering'
-data-importer.mapping.advanced-modal.transformer.group.data-types: 'Datatyper'
-data-importer.mapping.advanced-modal.transformer.group.load-import: 'Ladda / Importera'
-data-importer.mapping.advanced-modal.next-step: 'Nästa steg'
-data-importer.mapping.advanced-modal.previous-step: 'Föregående steg'
-data-importer.mapping.advanced-modal.recalculate-result-type: 'Beräkna om transformationsresultattyp'
-data-importer.mapping.advanced-modal.step-source.label: 'Källattribut'
-data-importer.mapping.advanced-modal.step-source.description: 'Välj från listan eller lägg till en ny källa'
-data-importer.mapping.advanced-modal.step-source.import-preview: 'Importförhandsvisning'
-data-importer.mapping.advanced-modal.step-source.search-placeholder: 'Sök'
-data-importer.mapping.advanced-modal.step-source.column-name: 'Namn'
-data-importer.mapping.advanced-modal.step-source.column-data: 'Data'
-data-importer.mapping.advanced-modal.loading: 'Laddar…'
-data-importer.mapping.advanced-modal.no-data: 'Inga data'
-data-importer.mapping.advanced-modal.no-preview: 'Ingen förhandsvisning tillgänglig'
-data-importer.mapping.advanced-modal.step-target.type: 'Typ'
-data-importer.mapping.advanced-modal.step-target.field-name: 'Fältnamn'
-data-importer.mapping.advanced-modal.step-target.overwrite: 'Skriv över'
-data-importer.mapping.advanced-modal.step-target.preview-result: 'Förhandsvisningsresultat'
-data-importer.mapping.advanced-modal.step-target.previous-step: 'Föregående steg'
-data-importer.mapping.advanced-modal.step-target.confirm-mapping: 'Bekräfta mapping'
-data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: 'Skriv till detta fält även om målfältet redan innehåller ett värde'
-data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: 'Skriv till detta fält även om källdata är tom'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode: 'Överskrivningsläge'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: 'Ersätt'
-data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: 'Sammanfoga'
-data-importer.mapping.advanced-modal.step-target.classification-store-key: 'Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: 'Ingen nyckel vald'
+data-importer.mapping.advanced-modal.title: Redigera mapping & transformationer
+data-importer.mapping.advanced-modal.save: Spara
+data-importer.mapping.advanced-modal.step-source: Källa
+data-importer.mapping.advanced-modal.step-transformations: Transformationer
+data-importer.mapping.advanced-modal.step-target: Datamål
+data-importer.mapping.advanced-modal.no-transformers: Inga transformatorer konfigurerade. Lägg till en nedan.
+data-importer.mapping.advanced-modal.add-transformation: + Lägg till transformation
+data-importer.mapping.advanced-modal.result-type: Resultattyp
+data-importer.mapping.advanced-modal.write-if-target-not-empty: Skriv om målet inte är tomt
+data-importer.mapping.advanced-modal.write-if-source-empty: Skriv om källan är tom
+data-importer.mapping.advanced-modal.transformer.move-up: Flytta upp
+data-importer.mapping.advanced-modal.transformer.move-down: Flytta ner
+data-importer.mapping.advanced-modal.transformer.remove: Ta bort
+data-importer.mapping.advanced-modal.transformer.edit-source: Redigera källattribut
+data-importer.mapping.advanced-modal.transformer.group.data-manipulation: Datamanipulering
+data-importer.mapping.advanced-modal.transformer.group.data-types: Datatyper
+data-importer.mapping.advanced-modal.transformer.group.load-import: Ladda / Importera
+data-importer.mapping.advanced-modal.next-step: Nästa steg
+data-importer.mapping.advanced-modal.previous-step: Föregående steg
+data-importer.mapping.advanced-modal.recalculate-result-type: Beräkna om transformationsresultattyp
+data-importer.mapping.advanced-modal.step-source.label: Källattribut
+data-importer.mapping.advanced-modal.step-source.description: Välj från listan eller lägg till en ny källa
+data-importer.mapping.advanced-modal.step-source.import-preview: Importförhandsvisning
+data-importer.mapping.advanced-modal.step-source.search-placeholder: Sök
+data-importer.mapping.advanced-modal.step-source.column-name: Namn
+data-importer.mapping.advanced-modal.step-source.column-data: Data
+data-importer.mapping.advanced-modal.loading: Laddar…
+data-importer.mapping.advanced-modal.no-data: Inga data
+data-importer.mapping.advanced-modal.no-preview: Ingen förhandsvisning tillgänglig
+data-importer.mapping.advanced-modal.step-target.type: Typ
+data-importer.mapping.advanced-modal.step-target.field-name: Fältnamn
+data-importer.mapping.advanced-modal.step-target.overwrite: Skriv över
+data-importer.mapping.advanced-modal.step-target.preview-result: Förhandsvisningsresultat
+data-importer.mapping.advanced-modal.step-target.previous-step: Föregående steg
+data-importer.mapping.advanced-modal.step-target.confirm-mapping: Bekräfta mapping
+data-importer.mapping.advanced-modal.step-target.write-if-target-not-empty.tooltip: Skriv till detta fält även om målfältet redan innehåller ett värde
+data-importer.mapping.advanced-modal.step-target.write-if-source-empty.tooltip: Skriv till detta fält även om källdata är tom
+data-importer.mapping.advanced-modal.step-target.overwrite-mode: Överskrivningsläge
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.replace: Ersätt
+data-importer.mapping.advanced-modal.step-target.overwrite-mode.merge: Sammanfoga
+data-importer.mapping.advanced-modal.step-target.classification-store-key: Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-placeholder: Ingen nyckel vald
 data-importer.mapping.advanced-modal.step-target.classification-store-key-in-group: '{{key}} i grupp {{group}}'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: 'Välj Classification Store Key'
-data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: 'Sök och välj en nyckel för detta Classification Store-fält'
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.title: Välj Classification Store Key
+data-importer.mapping.advanced-modal.step-target.classification-store-key-modal.description: Sök och välj en nyckel för detta Classification Store-fält
 data-importer.mapping.advanced-modal.step-target.type-error.classificationstoreBatch: 'Classification Store Batch kräver transformationsresultattyp: array, quantityValueArray, inputQuantityValueArray eller dateArray.'
 data-importer.mapping.advanced-modal.step-target.type-error.manyToManyRelation: 'Many-to-Many Relation kräver transformationsresultattyp: advancedDataObject, dataObjectArray, assetArray eller advancedAssetArray.'
 
-error.error_environment: 'Förhandsvisningsfilen är inte giltig för den konfigurerade tolken. Ladda upp eller kopiera förhandsvisningsdata på nytt.'
+error.error_environment: Förhandsvisningsfilen är inte giltig för den konfigurerade tolken. Ladda upp eller kopiera förhandsvisningsdata på nytt.
 
 # Execution Tab
-data-importer.execution.settings.title: 'Körningsinställningar'
-data-importer.execution.schedule-type: 'Schematyp'
-data-importer.execution.schedule-type.recurring: 'Återkommande / Cron'
-data-importer.execution.schedule-type.job: 'Engångsjobb'
-data-importer.execution.cron-definition: 'Cron-definition'
-data-importer.execution.cron-generator: 'Cron-generator'
-data-importer.execution.scheduled-at: 'Schemalagd till'
-data-importer.execution.manual-execution: 'Manuell körning'
-data-importer.execution.start-import: 'Starta import'
-data-importer.execution.start-import.success: 'Importen startades'
-data-importer.execution.start-import.error: 'Det gick inte att starta importen'
-data-importer.execution.start-import.tooltip-dirty: 'Spara dina ändringar innan du startar importen'
-data-importer.execution.start-import.tooltip-push: 'Push-laddaren stöder inte manuell körning'
-data-importer.execution.cancel.success: 'Importen avbröts'
-data-importer.execution.cancel.error: 'Det gick inte att avbryta importen'
-data-importer.execution.status.title: 'Körningsstatus'
-data-importer.execution.status.not-running: 'Körs inte'
-data-importer.execution.status.finished: 'Alla objekt bearbetade. Ingen import körs.'
-data-importer.execution.status.current-progress: 'Aktuellt förlopp'
+data-importer.execution.settings.title: Körningsinställningar
+data-importer.execution.schedule-type: Schematyp
+data-importer.execution.schedule-type.recurring: Återkommande / Cron
+data-importer.execution.schedule-type.job: Engångsjobb
+data-importer.execution.cron-definition: Cron-definition
+data-importer.execution.cron-generator: Cron-generator
+data-importer.execution.scheduled-at: Schemalagd till
+data-importer.execution.manual-execution: Manuell körning
+data-importer.execution.start-import: Starta import
+data-importer.execution.start-import.success: Importen startades
+data-importer.execution.start-import.error: Det gick inte att starta importen
+data-importer.execution.start-import.tooltip-dirty: Spara dina ändringar innan du startar importen
+data-importer.execution.start-import.tooltip-push: Push-laddaren stöder inte manuell körning
+data-importer.execution.cancel.success: Importen avbröts
+data-importer.execution.cancel.error: Det gick inte att avbryta importen
+data-importer.execution.status.title: Körningsstatus
+data-importer.execution.status.not-running: Körs inte
+data-importer.execution.status.finished: Alla objekt bearbetade. Ingen import körs.
+data-importer.execution.status.current-progress: Aktuellt förlopp
 data-importer.execution.status.processing: '{{processedItems}} / {{totalItems}} objekt bearbetade...'
-data-importer.execution.status.cancel: 'Avbryt körning & rensa kö'
-data-importer.execution.cron-validating: 'Validerar Cron-uttryck...'
+data-importer.execution.status.cancel: Avbryt körning & rensa kö
+data-importer.execution.cron-validating: Validerar Cron-uttryck...
 data-importer.validation.required: '{{field}} är obligatoriskt'


### PR DESCRIPTION
## Changes in this pull request
https://github.com/pimcore/studio-ui-bundle/issues/3207

Remove unnecessary quotes from translation YAML files. Only quotes required by YAML syntax are kept (interpolation placeholders, colons, special characters, boolean-like values, etc.).

## Additional info
- 1,515 unnecessary quotes removed across 6 files
- Validated with yaml.safe_load() — all values remain strings, no semantic changes