### PR TITLE
Fix misleading error message and default elementType in ResolverFactory

### DIFF
--- a/src/Resolver/ResolverFactory.php
+++ b/src/Resolver/ResolverFactory.php
@@ -111,7 +111,7 @@ class ResolverFactory
     protected function buildElementFactory(string $type, ?string $subType = null): FactoryInterface
     {
         if (empty($type) || !array_key_exists($type, $this->factoryBlueprints)) {
-            throw new InvalidConfigurationException('Unknown publishing strategy type `' . $type . '`');
+            throw new InvalidConfigurationException('Unknown element factory type `' . $type . '`');
         }
 
         $factory = clone $this->factoryBlueprints[$type];
@@ -129,7 +129,7 @@ class ResolverFactory
         $resolver->setCreateLocationStrategy($this->buildLocationStrategy($configuration['createLocationStrategy'] ?? []));
         $resolver->setLocationUpdateStrategy($this->buildLocationStrategy($configuration['locationUpdateStrategy'] ?? []));
         $resolver->setPublishingStrategy($this->buildPublishingStrategy($configuration['publishingStrategy']));
-        $resolver->setElementFactory($this->buildElementFactory($configuration['elementType'] ?? '', $resolver->getDataObjectClassId()));
+        $resolver->setElementFactory($this->buildElementFactory($configuration['elementType'] ?? 'dataObject', $resolver->getDataObjectClassId()));
 
         return $resolver;
     }


### PR DESCRIPTION
## Summary

- Fix copy-paste error in `buildElementFactory()` that incorrectly reported `Unknown publishing strategy type` instead of `Unknown element factory type`
- Default `elementType` to `'dataObject'` when not present in resolver config, fixing imported configurations that lack this field

## Problem

When importing a data importer configuration via JSON export/import, the `resolverConfig` may not contain an `elementType` key. The classic UI always injects `elementType: "dataObject"` via a hidden form field when saving, but this value is not always persisted in exported configurations.

When `elementType` is missing, `ResolverFactory::loadResolver()` falls back to an empty string, which fails in `buildElementFactory()`. Due to a copy-paste bug, the error message incorrectly says "Unknown publishing strategy type" instead of "Unknown element factory type", making the root cause very difficult to diagnose.

Resolves #591