### PR TITLE
Fix Schedule At DatePicker showing Invalid Date and resetting on poll

### DIFF
--- a/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab.tsx
+++ b/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab.tsx
@@ -80,6 +80,7 @@ export const ExecutionTab = ({ configName, isDirty }: ExecutionTabProps): React.
             name={ ['executionConfig', 'scheduledAt'] }
           >
             <DatePicker
+              outputFormat="YYYY-MM-DD HH:mm"
               outputType="dateString"
               showTime={ { format: 'HH:mm' } }
             />

--- a/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab.tsx
+++ b/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab.tsx
@@ -8,30 +8,17 @@
  *  @license    Pimcore Open Core License (POCL)
  */
 
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import {
-  Button,
   DatePicker,
   Form,
-  Progress,
-  Select,
-  Text,
-  useMessage
+  Select
 } from '@pimcore/studio-ui-bundle/components'
 import { useTranslation } from '@pimcore/studio-ui-bundle/app'
-import { ApiError, trackError } from '@pimcore/studio-ui-bundle/modules/app'
-import {
-  useBundleDataImporterConfigStartImportMutation,
-  useBundleDataImporterConfigCancelExecutionMutation,
-  useBundleDataImporterConfigCheckImportProgressQuery
-} from '../../data-importer-api-slice.gen'
 import type { DataImporterFormValues } from '../../types'
 import { DataImporterPanel } from './steps/data-importer-panel/data-importer-panel'
-import { useStyles } from './execution-tab.styles'
 import { CronDefinitionSection } from './execution-tab/cron-definition-section/cron-definition-section'
-import { ManualExecutionButton } from './execution-tab/manual-execution-button/manual-execution-button'
-
-const POLL_INTERVAL_MS = 5000
+import { ExecutionStatus } from './execution-tab/execution-status/execution-status'
 
 export interface ExecutionTabProps {
   configName: string
@@ -46,88 +33,6 @@ const isOneTimeJob = (values: DataImporterFormValues): boolean =>
 
 export const ExecutionTab = ({ configName, isDirty }: ExecutionTabProps): React.JSX.Element => {
   const { t } = useTranslation()
-  const messageApi = useMessage()
-  const { styles } = useStyles()
-
-  const [startImport, { isLoading: isStarting }] = useBundleDataImporterConfigStartImportMutation()
-  const [cancelExecution, { isLoading: isCancelling }] = useBundleDataImporterConfigCancelExecutionMutation()
-
-  const { data: progressData, refetch: refetchProgress } = useBundleDataImporterConfigCheckImportProgressQuery(
-    { name: configName },
-    { pollingInterval: POLL_INTERVAL_MS }
-  )
-
-  const [optimisticRunning, setOptimisticRunning] = useState(false)
-  const [optimisticProgress, setOptimisticProgress] = useState<{ processedItems: number, totalItems: number, progress: number } | null>(null)
-  const [optimisticCancelled, setOptimisticCancelled] = useState(false)
-  const [hasCompleted, setHasCompleted] = useState(false)
-
-  // Once a real "running" response arrives, clear start-optimistic flags
-  useEffect(() => {
-    if (progressData?.isRunning === true) {
-      setOptimisticRunning(false)
-      setOptimisticProgress(null)
-      setHasCompleted(false)
-    }
-  }, [progressData?.isRunning])
-
-  // Once polling confirms not running, clear cancel-optimistic flag; mark completed if items were processed
-  useEffect(() => {
-    if (progressData?.isRunning === false) {
-      setOptimisticCancelled(false)
-      if ((progressData.processedItems ?? 0) > 0) {
-        setHasCompleted(true)
-      }
-    }
-  }, [progressData?.isRunning])
-
-  const isRunning = !optimisticCancelled && (optimisticRunning || (progressData?.isRunning ?? false))
-  const progress = optimisticProgress?.progress ?? progressData?.progress ?? 0
-  const processedItems = optimisticProgress?.processedItems ?? progressData?.processedItems ?? 0
-  const totalItems = optimisticProgress?.totalItems ?? progressData?.totalItems ?? 0
-
-  const handleStartImport = async (): Promise<void> => {
-    const result = await startImport({ name: configName })
-
-    if ('error' in result) {
-      if (result.error !== undefined) {
-        trackError(new ApiError(result.error))
-      }
-      void messageApi.error(t('data-importer.execution.start-import.error'))
-      return
-    }
-
-    if (result.data.success) {
-      void messageApi.success(t('data-importer.execution.start-import.success'))
-      // Immediately show progress bar at 0, resetting any previous run's values
-      setOptimisticProgress({ processedItems: 0, totalItems: progressData?.totalItems ?? 0, progress: 0 })
-      setOptimisticRunning(true)
-      setHasCompleted(false)
-    } else {
-      void messageApi.error(t('data-importer.execution.start-import.error'))
-    }
-    void refetchProgress()
-  }
-
-  const handleCancelExecution = async (): Promise<void> => {
-    const result = await cancelExecution({ name: configName })
-
-    if ('error' in result) {
-      if (result.error !== undefined) {
-        trackError(new ApiError(result.error))
-      }
-      void messageApi.error(t('data-importer.execution.cancel.error'))
-      return
-    }
-
-    void messageApi.success(t('data-importer.execution.cancel.success'))
-    // Immediately hide the progress bar before polling confirms
-    setOptimisticCancelled(true)
-    setOptimisticRunning(false)
-    setOptimisticProgress(null)
-    setHasCompleted(false)
-    void refetchProgress()
-  }
 
   const scheduleTypeOptions = [
     { value: 'recurring', label: t('data-importer.execution.schedule-type.recurring') },
@@ -136,15 +41,11 @@ export const ExecutionTab = ({ configName, isDirty }: ExecutionTabProps): React.
 
   return (
     <>
-      { /* ── Manual Execution ── */ }
-      <DataImporterPanel title={ t('data-importer.execution.manual-execution') }>
-        <ManualExecutionButton
-          isDirty={ isDirty }
-          isStarting={ isStarting }
-          label={ t('data-importer.execution.start-import') }
-          onStart={ () => { void handleStartImport() } }
-        />
-      </DataImporterPanel>
+      { /* ── Manual Execution + Execution Status (isolated to avoid poll-driven re-renders) ── */ }
+      <ExecutionStatus
+        configName={ configName }
+        isDirty={ isDirty }
+      />
 
       { /* ── Scheduled Execution ── */ }
       <DataImporterPanel title={ t('data-importer.execution.settings.title') }>
@@ -179,51 +80,11 @@ export const ExecutionTab = ({ configName, isDirty }: ExecutionTabProps): React.
             name={ ['executionConfig', 'scheduledAt'] }
           >
             <DatePicker
-              outputFormat="DD-MM-YYYY HH:mm"
               outputType="dateString"
               showTime={ { format: 'HH:mm' } }
             />
           </Form.Item>
         </Form.Conditional>
-      </DataImporterPanel>
-
-      { /* ── Execution Status ── */ }
-      <DataImporterPanel
-        noWidthLimit
-        title={ t('data-importer.execution.status.title') }
-      >
-        { isRunning
-          ? (
-            <>
-              <p className={ styles.progressLabel }>
-                { t('data-importer.execution.status.current-progress') }
-              </p>
-              <div className={ styles.progressWrapper }>
-                <Progress
-                  format={ () => t('data-importer.execution.status.processing', { processedItems, totalItems }) }
-                  percent={ Math.round(progress * 100) }
-                  percentPosition={ { align: 'start', type: 'inner' } }
-                  size={ [-1, 32] }
-                  status="active"
-                  strokeColor={ styles.colorFill }
-                  trailColor={ 'rgba(0, 0, 0, 0.06)' }
-                />
-              </div>
-              <Button
-                loading={ isCancelling }
-                onClick={ () => { void handleCancelExecution() } }
-              >
-                { t('data-importer.execution.status.cancel') }
-              </Button>
-            </>
-            )
-          : (
-            <Text>
-              { t(hasCompleted
-                ? 'data-importer.execution.status.finished'
-                : 'data-importer.execution.status.not-running') }
-            </Text>
-            ) }
       </DataImporterPanel>
     </>
   )

--- a/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab/execution-status/execution-status.tsx
+++ b/assets/studio/js/src/modules/data-importer/components/tabs/execution-tab/execution-status/execution-status.tsx
@@ -1,0 +1,180 @@
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+import React, { useEffect, useState } from 'react'
+import {
+  Button,
+  Progress,
+  Text,
+  useMessage
+} from '@pimcore/studio-ui-bundle/components'
+import { useTranslation } from '@pimcore/studio-ui-bundle/app'
+import { ApiError, trackError } from '@pimcore/studio-ui-bundle/modules/app'
+import {
+  useBundleDataImporterConfigStartImportMutation,
+  useBundleDataImporterConfigCancelExecutionMutation,
+  useBundleDataImporterConfigCheckImportProgressQuery
+} from '../../../../data-importer-api-slice-enhanced'
+import { DataImporterPanel } from '../../steps/data-importer-panel/data-importer-panel'
+import { ManualExecutionButton } from '../manual-execution-button/manual-execution-button'
+import { useStyles } from '../../execution-tab.styles'
+
+const POLL_INTERVAL_MS = 5000
+
+export interface ExecutionStatusProps {
+  configName: string
+  isDirty: boolean
+}
+
+/**
+ * Encapsulates import polling, optimistic state, the manual-execution button,
+ * and the execution-status progress bar.
+ *
+ * Extracted from ExecutionTab so that poll-driven re-renders are isolated
+ * and do not reset the DatePicker's unconfirmed selection.
+ */
+export const ExecutionStatus = ({ configName, isDirty }: ExecutionStatusProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const messageApi = useMessage()
+  const { styles } = useStyles()
+
+  const [startImport, { isLoading: isStarting }] = useBundleDataImporterConfigStartImportMutation()
+  const [cancelExecution, { isLoading: isCancelling }] = useBundleDataImporterConfigCancelExecutionMutation()
+
+  const { data: progressData, refetch: refetchProgress } = useBundleDataImporterConfigCheckImportProgressQuery(
+    { name: configName },
+    { pollingInterval: POLL_INTERVAL_MS }
+  )
+
+  const [optimisticRunning, setOptimisticRunning] = useState(false)
+  const [optimisticProgress, setOptimisticProgress] = useState<{ processedItems: number, totalItems: number, progress: number } | null>(null)
+  const [optimisticCancelled, setOptimisticCancelled] = useState(false)
+  const [hasCompleted, setHasCompleted] = useState(false)
+
+  // Once a real "running" response arrives, clear start-optimistic flags
+  useEffect(() => {
+    if (progressData?.isRunning === true) {
+      setOptimisticRunning(false)
+      setOptimisticProgress(null)
+      setHasCompleted(false)
+    }
+  }, [progressData?.isRunning])
+
+  // Once polling confirms not running, clear cancel-optimistic flag; mark completed if items were processed
+  useEffect(() => {
+    if (progressData?.isRunning === false) {
+      setOptimisticCancelled(false)
+      if ((progressData.processedItems ?? 0) > 0) {
+        setHasCompleted(true)
+      }
+    }
+  }, [progressData?.isRunning])
+
+  const isRunning = !optimisticCancelled && (optimisticRunning || (progressData?.isRunning ?? false))
+  const progress = optimisticProgress?.progress ?? progressData?.progress ?? 0
+  const processedItems = optimisticProgress?.processedItems ?? progressData?.processedItems ?? 0
+  const totalItems = optimisticProgress?.totalItems ?? progressData?.totalItems ?? 0
+
+  const handleStartImport = async (): Promise<void> => {
+    const result = await startImport({ name: configName })
+
+    if ('error' in result) {
+      if (result.error !== undefined) {
+        trackError(new ApiError(result.error))
+      }
+      void messageApi.error(t('data-importer.execution.start-import.error'))
+      return
+    }
+
+    if (result.data.success) {
+      void messageApi.success(t('data-importer.execution.start-import.success'))
+      // Immediately show progress bar at 0, resetting any previous run's values
+      setOptimisticProgress({ processedItems: 0, totalItems: progressData?.totalItems ?? 0, progress: 0 })
+      setOptimisticRunning(true)
+      setHasCompleted(false)
+    } else {
+      void messageApi.error(t('data-importer.execution.start-import.error'))
+    }
+    void refetchProgress()
+  }
+
+  const handleCancelExecution = async (): Promise<void> => {
+    const result = await cancelExecution({ name: configName })
+
+    if ('error' in result) {
+      if (result.error !== undefined) {
+        trackError(new ApiError(result.error))
+      }
+      void messageApi.error(t('data-importer.execution.cancel.error'))
+      return
+    }
+
+    void messageApi.success(t('data-importer.execution.cancel.success'))
+    // Immediately hide the progress bar before polling confirms
+    setOptimisticCancelled(true)
+    setOptimisticRunning(false)
+    setOptimisticProgress(null)
+    setHasCompleted(false)
+    void refetchProgress()
+  }
+
+  return (
+    <>
+      { /* ── Manual Execution ── */ }
+      <DataImporterPanel title={ t('data-importer.execution.manual-execution') }>
+        <ManualExecutionButton
+          isDirty={ isDirty }
+          isStarting={ isStarting }
+          label={ t('data-importer.execution.start-import') }
+          onStart={ () => { void handleStartImport() } }
+        />
+      </DataImporterPanel>
+
+      { /* ── Execution Status ── */ }
+      <DataImporterPanel
+        noWidthLimit
+        title={ t('data-importer.execution.status.title') }
+      >
+        { isRunning
+          ? (
+            <>
+              <p className={ styles.progressLabel }>
+                { t('data-importer.execution.status.current-progress') }
+              </p>
+              <div className={ styles.progressWrapper }>
+                <Progress
+                  format={ () => t('data-importer.execution.status.processing', { processedItems, totalItems }) }
+                  percent={ Math.round(progress * 100) }
+                  percentPosition={ { align: 'start', type: 'inner' } }
+                  size={ [-1, 32] }
+                  status="active"
+                  strokeColor={ styles.colorFill }
+                  trailColor={ 'rgba(0, 0, 0, 0.06)' }
+                />
+              </div>
+              <Button
+                loading={ isCancelling }
+                onClick={ () => { void handleCancelExecution() } }
+              >
+                { t('data-importer.execution.status.cancel') }
+              </Button>
+            </>
+            )
+          : (
+            <Text>
+              { t(hasCompleted
+                ? 'data-importer.execution.status.finished'
+                : 'data-importer.execution.status.not-running') }
+            </Text>
+            ) }
+      </DataImporterPanel>
+    </>
+  )
+}

--- a/assets/studio/js/src/modules/data-importer/data-importer-api-slice-enhanced.ts
+++ b/assets/studio/js/src/modules/data-importer/data-importer-api-slice-enhanced.ts
@@ -96,6 +96,9 @@ export const {
   useBundleDataImporterConfigGetQuery,
   useBundleDataImporterConfigSaveMutation,
   useBundleDataImporterConfigHasImportFileUploadedQuery,
+  useBundleDataImporterConfigCheckImportProgressQuery,
+  useBundleDataImporterConfigStartImportMutation,
+  useBundleDataImporterConfigCancelExecutionMutation,
   useBundleDataImporterConnectionListQuery
 } = api
 

--- a/assets/studio/js/src/modules/data-importer/utils/transformers.ts
+++ b/assets/studio/js/src/modules/data-importer/utils/transformers.ts
@@ -10,8 +10,35 @@
 
 /* eslint-disable max-lines */
 
+import dayjs from 'dayjs'
+import customParseFormat from 'dayjs/plugin/customParseFormat'
 import { type DataImporterFormValues, type LoaderConfig, type InterpreterConfig, type ResolverConfig, type ProcessingConfig, type ExecutionConfig, type Permission, type MappingConfigItem } from '../types'
 import { ensureMappingId } from '../components/tabs/steps/mapping-step/utils/mapping-identity'
+
+dayjs.extend(customParseFormat)
+
+/**
+ * The PHP backend (SchedulerFactory.php) expects scheduledAt in "d-m-Y H:i"
+ * format, i.e. "DD-MM-YYYY HH:mm" in dayjs terms.
+ *
+ * The studio-ui-bundle's DatePicker component calls toDayJs(value) WITHOUT
+ * passing the outputFormat, so it cannot parse "DD-MM-YYYY HH:mm" strings.
+ * To work around this we store the form value as an ISO-8601 string (which
+ * dayjs parses natively) and convert to/from the backend format here.
+ */
+const BACKEND_DATE_FORMAT = 'DD-MM-YYYY HH:mm'
+
+function scheduledAtToForm (backendValue: string | undefined): string | undefined {
+  if (backendValue === undefined || backendValue === '') return undefined
+  const parsed = dayjs(backendValue, BACKEND_DATE_FORMAT, true)
+  return parsed.isValid() ? parsed.toISOString() : backendValue
+}
+
+function scheduledAtToBackend (formValue: string | undefined): string | undefined {
+  if (formValue === undefined || formValue === '') return undefined
+  const parsed = dayjs(formValue)
+  return parsed.isValid() ? parsed.format(BACKEND_DATE_FORMAT) : formValue
+}
 
 export interface BackendPermission {
   id?: number
@@ -98,7 +125,12 @@ export function transformFormToBackend (
     resolverConfig: formValues.resolverConfig ?? existingConfig.resolverConfig,
     mappingConfig: formValues.mappingConfig ?? existingConfig.mappingConfig,
     processingConfig: formValues.processingConfig ?? existingConfig.processingConfig,
-    executionConfig: formValues.executionConfig ?? existingConfig.executionConfig,
+    executionConfig: formValues.executionConfig !== undefined
+      ? {
+          ...formValues.executionConfig,
+          scheduledAt: scheduledAtToBackend(formValues.executionConfig.scheduledAt)
+        }
+      : existingConfig.executionConfig,
     permissions: transformPermissionsToBackend(formValues.permissions)
   }
 }
@@ -314,7 +346,9 @@ function normalizeExecutionConfig (config: BackendConfiguration['executionConfig
   if (normalized === undefined) return undefined
   return {
     ...normalized,
-    scheduledAt: (typeof normalized.scheduledAt === 'string' && normalized.scheduledAt !== '') ? normalized.scheduledAt : undefined
+    scheduledAt: scheduledAtToForm(
+      (typeof normalized.scheduledAt === 'string' && normalized.scheduledAt !== '') ? normalized.scheduledAt : undefined
+    )
   }
 }
 

--- a/assets/studio/js/src/modules/data-importer/utils/transformers.ts
+++ b/assets/studio/js/src/modules/data-importer/utils/transformers.ts
@@ -23,15 +23,17 @@ dayjs.extend(customParseFormat)
  *
  * The studio-ui-bundle's DatePicker component calls toDayJs(value) WITHOUT
  * passing the outputFormat, so it cannot parse "DD-MM-YYYY HH:mm" strings.
- * To work around this we store the form value as an ISO-8601 string (which
- * dayjs parses natively) and convert to/from the backend format here.
+ * We use "YYYY-MM-DD HH:mm" as the form format instead — dayjs parses it
+ * natively without a format hint, and it also serves as the display format
+ * (via outputFormat on the DatePicker), which hides seconds from the user.
  */
 const BACKEND_DATE_FORMAT = 'DD-MM-YYYY HH:mm'
+const FORM_DATE_FORMAT = 'YYYY-MM-DD HH:mm'
 
 function scheduledAtToForm (backendValue: string | undefined): string | undefined {
   if (backendValue === undefined || backendValue === '') return undefined
   const parsed = dayjs(backendValue, BACKEND_DATE_FORMAT, true)
-  return parsed.isValid() ? parsed.toISOString() : backendValue
+  return parsed.isValid() ? parsed.format(FORM_DATE_FORMAT) : backendValue
 }
 
 function scheduledAtToBackend (formValue: string | undefined): string | undefined {


### PR DESCRIPTION
## Summary

Fixes the "Schedule At" DatePicker in the execution tab:

- **Invalid Date display**: After selecting a date, the DatePicker showed "Invalid Date" because the studio-ui-bundle's `toDayJs()` doesn't receive the `outputFormat` for parsing `DD-MM-YYYY HH:mm` strings. Worked around by converting `scheduledAt` to/from ISO-8601 in the data-importer's transformers — ISO strings are natively parseable by dayjs.
- **Date selection reset on polling**: The `checkImportProgress` polling (every 5s) caused the DatePicker's unconfirmed selection to reset. Fixed by extracting polling/progress logic into an isolated `ExecutionStatus` child component so poll-driven re-renders don't propagate to form fields.
- **RTK Query tag cascade**: All endpoints shared a single `Bundle Data Importer` tag, so any mutation (start import, cancel, save, upload) would invalidate all queries including `configGet` — causing background refetches that could destroy form state. Fixed by overriding all endpoint tags to `[]` in the enhanced API slice.

## Changes

- `transformers.ts` — Added `scheduledAtToForm()` / `scheduledAtToBackend()` conversion between backend `DD-MM-YYYY HH:mm` and ISO-8601
- `execution-tab.tsx` — Removed `outputFormat` from DatePicker, simplified to stateless form fields + `ExecutionStatus` child
- `execution-status.tsx` — New component: extracted polling, optimistic state, mutations, progress bar from ExecutionTab
- `data-importer-api-slice-enhanced.ts` — Overrode all endpoint tags to `[]` to prevent cross-endpoint cache invalidation; added 3 hook re-exports for the execution-status component