### PR TITLE
Rename JSON interpreter path label to JMESPath

### DIFF
--- a/src/Resources/translations/studio.de.yaml
+++ b/src/Resources/translations/studio.de.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Erste Zeile überspringen
 data-importer.interpreter.csv.save-header-name: Kopfzeilennamen speichern
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Pfad
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.en.yaml
+++ b/src/Resources/translations/studio.en.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Skip First Row
 data-importer.interpreter.csv.save-header-name: Save Header Name
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Path
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.es.yaml
+++ b/src/Resources/translations/studio.es.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Omitir primera fila
 data-importer.interpreter.csv.save-header-name: Guardar nombre de encabezado
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Ruta
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.fr.yaml
+++ b/src/Resources/translations/studio.fr.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Ignorer la première ligne
 data-importer.interpreter.csv.save-header-name: 'Enregistrer le nom d''en-tête'
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Chemin
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.it.yaml
+++ b/src/Resources/translations/studio.it.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Salta la prima riga
 data-importer.interpreter.csv.save-header-name: Salva nome intestazione
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Percorso
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.no.yaml
+++ b/src/Resources/translations/studio.no.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Hopp over første rad
 data-importer.interpreter.csv.save-header-name: Lagre overskriftsnavn
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Sti
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath

--- a/src/Resources/translations/studio.sv.yaml
+++ b/src/Resources/translations/studio.sv.yaml
@@ -89,7 +89,7 @@ data-importer.interpreter.csv.skip-first-row: Hoppa över första raden
 data-importer.interpreter.csv.save-header-name: Spara rubriknamn
 
 # JSON Interpreter
-data-importer.interpreter.json.path: Sökväg
+data-importer.interpreter.json.path: JMESPath
 
 # XML Interpreter
 data-importer.interpreter.xml.xpath: XPath


### PR DESCRIPTION
## Changes in this pull request
Resolves #554

Renames the JSON interpreter path field label in the Studio UI to `JMESPath`, matching the ExtJS label (`plugin_pimcore_datahub_data_importer_configpanel_json_path: JMESPath` in `admin.en.yml`). Applied across all studio locale files.

## Additional info