### PR TITLE
[Bug]: Update attributeLanguage type to nullable string

### DIFF
--- a/src/Resolver/Load/AttributeStrategy.php
+++ b/src/Resolver/Load/AttributeStrategy.php
@@ -23,7 +23,7 @@ class AttributeStrategy extends AbstractLoad
     protected $attributeName;
 
     /**
-     * @var string
+     * @var ?string
      */
     protected $attributeLanguage;
 

--- a/src/Resolver/Load/AttributeStrategy.php
+++ b/src/Resolver/Load/AttributeStrategy.php
@@ -23,7 +23,7 @@ class AttributeStrategy extends AbstractLoad
     protected $attributeName;
 
     /**
-     * @var ?string
+     * @var string
      */
     protected $attributeLanguage;
 
@@ -46,7 +46,7 @@ class AttributeStrategy extends AbstractLoad
         }
 
         $this->attributeName = $settings['attributeName'];
-        $this->attributeLanguage = $settings['language'] ?? null;
+        $this->attributeLanguage = $settings['language'] ?? '';
         $this->includeUnpublished = $settings['includeUnpublished'] ?? false;
     }
 

--- a/src/Tool/DataObjectLoader.php
+++ b/src/Tool/DataObjectLoader.php
@@ -61,7 +61,7 @@ class DataObjectLoader
     public function loadByAttribute(string $className,
         string $attributeName,
         string $identifier,
-        string $attributeLanguage = '',
+        ?string $attributeLanguage = null,
         bool $includeUnpublished = false,
         int $limit = 0,
         string $operator = '='): ?ElementInterface
@@ -133,7 +133,7 @@ class DataObjectLoader
         string $attributeName,
         string $className,
         string $identifier,
-        string $attributeLanguage,
+        ?string $attributeLanguage,
         int $limit,
         array $objectTypes
     ): ?ElementInterface {

--- a/src/Tool/DataObjectLoader.php
+++ b/src/Tool/DataObjectLoader.php
@@ -61,7 +61,7 @@ class DataObjectLoader
     public function loadByAttribute(string $className,
         string $attributeName,
         string $identifier,
-        ?string $attributeLanguage = null,
+        string $attributeLanguage = '',
         bool $includeUnpublished = false,
         int $limit = 0,
         string $operator = '='): ?ElementInterface


### PR DESCRIPTION
## Changes in this pull request
Resolves #616

## Additional info
It would be better to make $attributeLanguage nullable but this would be a BC Break. Used methods are not nullable 

Admin Classis sends it as empty string when not set. 