### PR TITLE
Allow setting object path via mapping data target

### DIFF
--- a/doc/03_Configuration/06_Mapping_Configuration/03_Data_Target/README.md
+++ b/doc/03_Configuration/06_Mapping_Configuration/03_Data_Target/README.md
@@ -15,6 +15,15 @@ schema for Object brick fields is `<OBJECT_BRICK_FIELD>.<OBJECT_BRICK_TYPE>.<ATT
 
 > The availability of target fields depends on the settings and the result type of the transformation pipeline. 
 
+In addition to class attributes, the following system fields can be written directly:
+
+- **SYSTEM Key**: Sets the `key` (name) of the element.
+- **SYSTEM Path**: Sets the parent folder of the element. The folder structure is created automatically if it does
+  not exist yet. This is equivalent to configuring the location through the [Resolver Settings](../../04_Resolver_Settings.md),
+  but lets you compose the path from the import data using the transformation pipeline. When used, set the
+  *Element Creation* / *Element Location Update* strategy to `No Change` so the resolver does not override the
+  path computed by the mapping.
+
 ### Classification Store
 Assign data to specific keys in a classification store. 
 

--- a/src/Mapping/DataTarget/Direct.php
+++ b/src/Mapping/DataTarget/Direct.php
@@ -13,9 +13,11 @@
 namespace Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget;
 
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
+use Pimcore\Model\Asset;
 use Pimcore\Model\DataObject;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\ClassDefinition\Data\Localizedfields;
+use Pimcore\Model\Document;
 use Pimcore\Model\Element\ElementInterface;
 
 /**
@@ -79,6 +81,11 @@ class Direct implements DataTargetInterface
                 return;
             }
             $this->doAssignData($element, $this->fieldName, $data);
+        } elseif ($this->fieldName === 'path') {
+            if (!$this->checkAssignData($data, $element, 'getPath')) {
+                return;
+            }
+            $this->doAssignPath($element, $data);
         } elseif (count($setterParts) === 1) {
             //direct class attribute
             $getter = 'get' . ucfirst($this->fieldName);
@@ -126,6 +133,31 @@ class Direct implements DataTargetInterface
     }
 
     /**
+     * Sets the element's parent based on a path, creating the necessary folder
+     * structure if it does not exist yet.
+     *
+     * @throws InvalidConfigurationException
+     */
+    protected function doAssignPath(ElementInterface $element, mixed $data): void
+    {
+        $path = (string) $data;
+        if ($path === '') {
+            return;
+        }
+
+        $parent = match (true) {
+            $element instanceof DataObject => DataObject\Service::createFolderByPath($path),
+            $element instanceof Asset => Asset\Service::createFolderByPath($path),
+            $element instanceof Document => Document\Service::createFolderByPath($path),
+            default => throw new InvalidConfigurationException(
+                sprintf('Cannot set path for element of type "%s".', $element::class)
+            ),
+        };
+
+        $element->setParent($parent);
+    }
+
+    /**
      * @param mixed $newData
      * @param object $valueContainer
      * @param string $getter
@@ -152,7 +184,7 @@ class Direct implements DataTargetInterface
             $fieldName = $fieldNameParts[2];
         }
 
-        if ($this->fieldName === 'key' || $this->fieldName === 'type') {
+        if ($this->fieldName === 'key' || $this->fieldName === 'type' || $this->fieldName === 'path') {
             $currentDataIsEmpty = empty($currentData);
             $newDataIsEmpty = empty($newData);
         } else {

--- a/src/Mapping/Type/TransformationDataTypeService.php
+++ b/src/Mapping/Type/TransformationDataTypeService.php
@@ -274,6 +274,11 @@ final class TransformationDataTypeService
                     'title' => 'SYSTEM Key',
                     'localized' => false
                 ];
+                $attributes['path'] = [
+                    'key' => 'path',
+                    'title' => 'SYSTEM Path',
+                    'localized' => false
+                ];
             }
         }
 

--- a/tests/unit/DirectDataTargetTest.php
+++ b/tests/unit/DirectDataTargetTest.php
@@ -1,0 +1,45 @@
+<?php declare(strict_types=1);
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
+use Pimcore\Bundle\DataImporterBundle\Mapping\DataTarget\Direct;
+use Pimcore\Model\Element\ElementInterface;
+
+class DirectDataTargetTest extends Unit
+{
+    protected $tester;
+
+    public function testEmptyFieldNameThrows(): void
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $target = new Direct();
+        $target->setSettings([]);
+    }
+
+    public function testPathOnUnsupportedElementTypeThrows(): void
+    {
+        $target = new Direct();
+        $target->setSettings(['fieldName' => 'path']);
+
+        // A generic element that is neither a DataObject, Asset nor Document
+        // cannot have its parent resolved from a path.
+        $element = $this->createMock(ElementInterface::class);
+
+        $this->expectException(InvalidConfigurationException::class);
+        $target->assignData($element, '/some/folder');
+    }
+
+    public function testEmptyPathIsSkipped(): void
+    {
+        $target = new Direct();
+        $target->setSettings(['fieldName' => 'path']);
+
+        $element = $this->createMock(ElementInterface::class);
+
+        // No exception expected and no folder resolution: an empty path is a no-op.
+        $target->assignData($element, '');
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
Unify the configuration of the element key and path. Previously the path (parent folder) could only be set through the resolver location strategies, while the key was a regular mapping target. The path can now be assigned through the "Direct" data target using the "SYSTEM Path" system field, which lets the path be composed from the import data via the transformation pipeline and creates the folder structure automatically.

## Changes in this pull request
Resolves #444

## Additional info
