### PR TITLE
[Bug]: Data Importer FindParentStrategy syntax error

### DIFF
--- a/src/Resolver/Location/FindParentStrategy.php
+++ b/src/Resolver/Location/FindParentStrategy.php
@@ -95,7 +95,7 @@ class FindParentStrategy implements LocationStrategyInterface
             }
 
             $this->attributeName = $settings['attributeName'];
-            $this->attributeLanguage = $settings['attributeLanguage'] ?? null;
+            $this->attributeLanguage = $settings['attributeLanguage'] ?? '';
         }
     }
 


### PR DESCRIPTION
## Changes in this pull request
Resolves https://github.com/pimcore/data-importer/issues/634

## Additional info
Follow up https://github.com/pimcore/data-importer/pull/617

It would be better to make $attributeLanguage nullable but this would be a BC Break. Used methods are not nullable

Admin Classis sends it as empty string when not set.