### PR TITLE
Require pimcore/data-hub ^2.4.3 (config permission fixes)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "nesbot/carbon": "^2.72 || ^3.8.4",
         "phpoffice/phpspreadsheet": "^2.2 || ^3.3",
         "pimcore/admin-ui-classic-bundle": "^2.0",
-        "pimcore/data-hub": "^2.4",
+        "pimcore/data-hub": "^2.4.3",
         "pimcore/pimcore": "^12.3",
         "pimcore/studio-backend-bundle": "^2025.4",
         "webmozarts/console-parallelization": "^1.2.0 || ^2.0.0"


### PR DESCRIPTION
Bumps `pimcore/data-hub` to `^2.4.3` so this release line pulls in the data hub Studio **config permission fixes** (read-only form without update permission, hide delete without delete permission, single error dialog) — i.e. the backend changes the data-importer Studio UI relies on.

⚠️ **Do not merge until `pimcore/data-hub` `2.4.3` is released.** Kept as a draft.
