### PR TITLE
Require pimcore/data-hub ^2026.1.3 (config permission fixes)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "mtdowling/jmespath.php": "^2.8",
     "nesbot/carbon": "^2.72 || ^3.8.4",
     "phpoffice/phpspreadsheet": "^4.3 || ^5.1",
-    "pimcore/data-hub": "^2026.1",
+    "pimcore/data-hub": "^2026.1.3",
     "pimcore/pimcore": "^2026.1",
     "pimcore/studio-backend-bundle": "^2026.1",
     "pimcore/studio-ui-bundle": "^2026.1",


### PR DESCRIPTION
Bumps `pimcore/data-hub` to `^2026.1.3` so this release line pulls in the data hub Studio **config permission fixes** (read-only form without update permission, hide delete without delete permission, single error dialog) — i.e. the backend changes the data-importer Studio UI relies on.

⚠️ **Do not merge until `pimcore/data-hub` `2026.1.3` is released.** Kept as a draft.
