### PR TITLE
[BUG] Fixes preview crashing on large files

### DIFF
--- a/src/DataSource/Interpreter/PreviewRowsReadFilter.php
+++ b/src/DataSource/Interpreter/PreviewRowsReadFilter.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
+
+use PhpOffice\PhpSpreadsheet\Reader\IReadFilter;
+
+/**
+ * Restricts spreadsheet reading to the given row numbers so previews do not
+ * need to load the whole workbook into memory.
+ *
+ * @internal
+ */
+final class PreviewRowsReadFilter implements IReadFilter
+{
+    /**
+     * @var array<int, true>
+     */
+    private array $rows;
+
+    /**
+     * @param int[] $rows 1-based row numbers to read
+     */
+    public function __construct(array $rows)
+    {
+        $this->rows = array_fill_keys($rows, true);
+    }
+
+    public function readCell(string $columnAddress, int $row, string $worksheetName = ''): bool
+    {
+        return isset($this->rows[$row]);
+    }
+}

--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -14,6 +14,7 @@ namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
+use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 
 /**
@@ -84,7 +85,14 @@ final class XlsxFileInterpreter extends AbstractInterpreter
      */
     private function loadPreviewRows(string $path, int $recordNumber): ?array
     {
-        $totalRows = $this->getTotalRows($path);
+        $worksheetInfo = $this->getWorksheetInfo($path);
+
+        if ($worksheetInfo === null) {
+            throw new InvalidConfigurationException(sprintf('Sheet "%s" not found in file.', $this->sheetName));
+        }
+
+        $totalRows = $worksheetInfo['totalRows'];
+        $lastColumnLetter = $worksheetInfo['lastColumnLetter'];
         $headerRowNumber = $this->skipFirstRow ? 1 : 0;
         $totalDataRows = max(0, $totalRows - $headerRowNumber);
 
@@ -94,7 +102,8 @@ final class XlsxFileInterpreter extends AbstractInterpreter
 
         $targetRowNumber = $headerRowNumber + 1 + $recordNumber;
         $readRecordNumber = $recordNumber;
-        if ($targetRowNumber > $totalRows) {
+        if ($recordNumber < 0 || $targetRowNumber > $totalRows) {
+            // fall back to the last data row, mirroring the previous out-of-range behavior
             $targetRowNumber = $totalRows;
             $readRecordNumber = $totalDataRows - 1;
         }
@@ -108,14 +117,14 @@ final class XlsxFileInterpreter extends AbstractInterpreter
         $spreadSheet->setActiveSheetIndexByName($this->sheetName);
         $sheet = $spreadSheet->getActiveSheet();
 
-        $headerRow = $this->skipFirstRow ? $this->readRow($sheet, $headerRowNumber) : null;
+        $headerRow = $this->skipFirstRow ? $this->readRow($sheet, $headerRowNumber, $lastColumnLetter) : null;
 
-        return [$headerRow, $this->readRow($sheet, $targetRowNumber), $readRecordNumber];
+        return [$headerRow, $this->readRow($sheet, $targetRowNumber, $lastColumnLetter), $readRecordNumber];
     }
 
-    private function readRow(Worksheet $sheet, int $rowNumber): array
+    private function readRow(Worksheet $sheet, int $rowNumber, string $lastColumnLetter): array
     {
-        $range = 'A' . $rowNumber . ':' . $sheet->getHighestColumn() . $rowNumber;
+        $range = 'A' . $rowNumber . ':' . $lastColumnLetter . $rowNumber;
 
         return $sheet->rangeToArray($range)[0];
     }
@@ -131,17 +140,26 @@ final class XlsxFileInterpreter extends AbstractInterpreter
         return $columns;
     }
 
-    private function getTotalRows(string $path): int
+    /**
+     * Reads the worksheet dimensions without loading any cells.
+     * Returns null when the configured sheet does not exist in the file.
+     *
+     * @return array{totalRows: int, lastColumnLetter: string}|null
+     */
+    private function getWorksheetInfo(string $path): ?array
     {
         $reader = IOFactory::createReaderForFile($path);
 
         foreach ($reader->listWorksheetInfo($path) as $worksheetInfo) {
             if (($worksheetInfo['worksheetName'] ?? null) === $this->sheetName) {
-                return (int)($worksheetInfo['totalRows'] ?? 0);
+                return [
+                    'totalRows' => (int)($worksheetInfo['totalRows'] ?? 0),
+                    'lastColumnLetter' => (string)($worksheetInfo['lastColumnLetter'] ?? 'A'),
+                ];
             }
         }
 
-        return 0;
+        return null;
     }
 
     public function setSettings(array $settings): void

--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -13,6 +13,7 @@
 namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
 
 /**
@@ -56,52 +57,78 @@ final class XlsxFileInterpreter extends AbstractInterpreter
         $columns = [];
         $readRecordNumber = 0;
 
-        if ($this->fileValid($path)) {
-            $totalRows = $this->getTotalRows($path);
-            $headerRowNumber = $this->skipFirstRow ? 1 : 0;
-            $totalDataRows = max(0, $totalRows - $headerRowNumber);
+        $rows = $this->fileValid($path) ? $this->loadPreviewRows($path, $recordNumber) : null;
 
-            if ($totalDataRows > 0) {
-                $targetRowNumber = $headerRowNumber + 1 + $recordNumber;
-                if ($targetRowNumber > $totalRows) {
-                    $targetRowNumber = $totalRows;
-                    $readRecordNumber = $totalDataRows - 1;
-                } else {
-                    $readRecordNumber = $recordNumber;
-                }
+        if ($rows !== null) {
+            [$headerRow, $previewDataRow, $readRecordNumber] = $rows;
 
-                // Only load the header row and the requested data row instead of the
-                // whole workbook - large files would otherwise exhaust the memory limit.
-                $reader = IOFactory::createReaderForFile($path);
-                $reader->setReadDataOnly(true);
-                $reader->setLoadSheetsOnly($this->sheetName);
-                $reader->setReadFilter(new PreviewRowsReadFilter(array_filter([$headerRowNumber, $targetRowNumber])));
-                $spreadSheet = $reader->load($path);
+            $columns = $this->extractColumns($headerRow);
 
-                $spreadSheet->setActiveSheetIndexByName($this->sheetName);
-                $sheet = $spreadSheet->getActiveSheet();
-                $highestColumn = $sheet->getHighestColumn();
+            foreach ($previewDataRow as $index => $columnData) {
+                $previewData[$index] = $columnData;
+            }
 
-                if ($this->skipFirstRow) {
-                    $firstRow = $sheet->rangeToArray('A' . $headerRowNumber . ':' . $highestColumn . $headerRowNumber)[0];
-                    foreach ($firstRow as $index => $columnHeader) {
-                        $columns[$index] = trim((string)$columnHeader) . " [$index]";
-                    }
-                }
-
-                $previewDataRow = $sheet->rangeToArray('A' . $targetRowNumber . ':' . $highestColumn . $targetRowNumber)[0];
-
-                foreach ($previewDataRow as $index => $columnData) {
-                    $previewData[$index] = $columnData;
-                }
-
-                if (empty($columns)) {
-                    $columns = array_keys($previewData);
-                }
+            if (empty($columns)) {
+                $columns = array_keys($previewData);
             }
         }
 
         return new PreviewData($columns, $previewData, $readRecordNumber, $mappedColumns);
+    }
+
+    /**
+     * Reads the header row and the requested data row without loading the whole
+     * workbook - large files would otherwise exhaust the memory limit.
+     *
+     * @return array{0: ?array, 1: array, 2: int}|null
+     */
+    private function loadPreviewRows(string $path, int $recordNumber): ?array
+    {
+        $totalRows = $this->getTotalRows($path);
+        $headerRowNumber = $this->skipFirstRow ? 1 : 0;
+        $totalDataRows = max(0, $totalRows - $headerRowNumber);
+
+        if ($totalDataRows < 1) {
+            return null;
+        }
+
+        $targetRowNumber = $headerRowNumber + 1 + $recordNumber;
+        $readRecordNumber = $recordNumber;
+        if ($targetRowNumber > $totalRows) {
+            $targetRowNumber = $totalRows;
+            $readRecordNumber = $totalDataRows - 1;
+        }
+
+        $reader = IOFactory::createReaderForFile($path);
+        $reader->setReadDataOnly(true);
+        $reader->setLoadSheetsOnly($this->sheetName);
+        $reader->setReadFilter(new PreviewRowsReadFilter(array_filter([$headerRowNumber, $targetRowNumber])));
+        $spreadSheet = $reader->load($path);
+
+        $spreadSheet->setActiveSheetIndexByName($this->sheetName);
+        $sheet = $spreadSheet->getActiveSheet();
+
+        $headerRow = $this->skipFirstRow ? $this->readRow($sheet, $headerRowNumber) : null;
+
+        return [$headerRow, $this->readRow($sheet, $targetRowNumber), $readRecordNumber];
+    }
+
+    private function readRow(Worksheet $sheet, int $rowNumber): array
+    {
+        $range = 'A' . $rowNumber . ':' . $sheet->getHighestColumn() . $rowNumber;
+
+        return $sheet->rangeToArray($range)[0];
+    }
+
+    private function extractColumns(?array $headerRow): array
+    {
+        $columns = [];
+
+        foreach ($headerRow ?? [] as $index => $columnHeader) {
+            $columns[$index] = trim((string)$columnHeader) . " [$index]";
+        }
+
+        return $columns;
     }
 
     private function getTotalRows(string $path): int

--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -12,7 +12,11 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\DataSource\Interpreter;
 
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\Coordinate;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\IOFactory;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
 use Pimcore\Bundle\DataImporterBundle\Exception\InvalidConfigurationException;
 use Pimcore\Bundle\DataImporterBundle\Preview\Model\PreviewData;
@@ -124,9 +128,42 @@ final class XlsxFileInterpreter extends AbstractInterpreter
 
     private function readRow(Worksheet $sheet, int $rowNumber, string $lastColumnLetter): array
     {
-        $range = 'A' . $rowNumber . ':' . $lastColumnLetter . $rowNumber;
+        $lastColumnIndex = Coordinate::columnIndexFromString($lastColumnLetter);
+        $rowData = [];
 
-        return $sheet->rangeToArray($range)[0];
+        for ($column = 1; $column <= $lastColumnIndex; $column++) {
+            $rowData[] = $this->getPreviewCellValue($sheet->getCell([$column, $rowNumber]));
+        }
+
+        return $rowData;
+    }
+
+    /**
+     * Formula cells prefer the result cached in the file: only parts of the
+     * workbook are loaded for previews, so recalculating formulas with
+     * cross-row or cross-sheet references would silently produce wrong
+     * values ("#REF!", zeros).
+     */
+    private function getPreviewCellValue(Cell $cell): mixed
+    {
+        if ($cell->getDataType() === DataType::TYPE_FORMULA) {
+            $cachedValue = $cell->getOldCalculatedValue();
+            if ($cachedValue !== null) {
+                return $cachedValue;
+            }
+        }
+
+        try {
+            $value = $cell->getCalculatedValue();
+        } catch (\Throwable) {
+            return null;
+        }
+
+        if ($value instanceof RichText) {
+            return $value->getPlainText();
+        }
+
+        return $value;
     }
 
     private function extractColumns(?array $headerRow): array

--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -57,40 +57,64 @@ final class XlsxFileInterpreter extends AbstractInterpreter
         $readRecordNumber = 0;
 
         if ($this->fileValid($path)) {
-            $reader = IOFactory::createReaderForFile($path);
-            $reader->setReadDataOnly(true);
-            $spreadSheet = $reader->load($path);
+            $totalRows = $this->getTotalRows($path);
+            $headerRowNumber = $this->skipFirstRow ? 1 : 0;
+            $totalDataRows = max(0, $totalRows - $headerRowNumber);
 
-            $spreadSheet->setActiveSheetIndexByName($this->sheetName);
-
-            $data = $spreadSheet->getActiveSheet()->toArray();
-
-            if ($this->skipFirstRow) {
-                $firstRow = array_shift($data);
-                foreach ($firstRow as $index => $columnHeader) {
-                    $columns[$index] = trim($columnHeader) . " [$index]";
+            if ($totalDataRows > 0) {
+                $targetRowNumber = $headerRowNumber + 1 + $recordNumber;
+                if ($targetRowNumber > $totalRows) {
+                    $targetRowNumber = $totalRows;
+                    $readRecordNumber = $totalDataRows - 1;
+                } else {
+                    $readRecordNumber = $recordNumber;
                 }
-            }
 
-            $previewDataRow = $data[$recordNumber] ?? null;
+                // Only load the header row and the requested data row instead of the
+                // whole workbook - large files would otherwise exhaust the memory limit.
+                $reader = IOFactory::createReaderForFile($path);
+                $reader->setReadDataOnly(true);
+                $reader->setLoadSheetsOnly($this->sheetName);
+                $reader->setReadFilter(new PreviewRowsReadFilter(array_filter([$headerRowNumber, $targetRowNumber])));
+                $spreadSheet = $reader->load($path);
 
-            if (empty($previewDataRow)) {
-                $previewDataRow = end($data);
-                $readRecordNumber = count($data) - 1;
-            } else {
-                $readRecordNumber = $recordNumber;
-            }
+                $spreadSheet->setActiveSheetIndexByName($this->sheetName);
+                $sheet = $spreadSheet->getActiveSheet();
+                $highestColumn = $sheet->getHighestColumn();
 
-            foreach ($previewDataRow as $index => $columnData) {
-                $previewData[$index] = $columnData;
-            }
+                if ($this->skipFirstRow) {
+                    $firstRow = $sheet->rangeToArray('A' . $headerRowNumber . ':' . $highestColumn . $headerRowNumber)[0];
+                    foreach ($firstRow as $index => $columnHeader) {
+                        $columns[$index] = trim((string)$columnHeader) . " [$index]";
+                    }
+                }
 
-            if (empty($columns)) {
-                $columns = array_keys($previewData);
+                $previewDataRow = $sheet->rangeToArray('A' . $targetRowNumber . ':' . $highestColumn . $targetRowNumber)[0];
+
+                foreach ($previewDataRow as $index => $columnData) {
+                    $previewData[$index] = $columnData;
+                }
+
+                if (empty($columns)) {
+                    $columns = array_keys($previewData);
+                }
             }
         }
 
         return new PreviewData($columns, $previewData, $readRecordNumber, $mappedColumns);
+    }
+
+    private function getTotalRows(string $path): int
+    {
+        $reader = IOFactory::createReaderForFile($path);
+
+        foreach ($reader->listWorksheetInfo($path) as $worksheetInfo) {
+            if (($worksheetInfo['worksheetName'] ?? null) === $this->sheetName) {
+                return (int)($worksheetInfo['totalRows'] ?? 0);
+            }
+        }
+
+        return 0;
     }
 
     public function setSettings(array $settings): void

--- a/src/DataSource/Loader/AssetLoader.php
+++ b/src/DataSource/Loader/AssetLoader.php
@@ -47,6 +47,10 @@ final class AssetLoader implements DataLoaderInterface
 
     public function cleanup(): void
     {
-        unlink($this->temporaryFile);
+        if ($this->temporaryFile !== null && is_file($this->temporaryFile)) {
+            unlink($this->temporaryFile);
+        }
+
+        $this->temporaryFile = null;
     }
 }

--- a/src/Service/Studio/PreviewDataService.php
+++ b/src/Service/Studio/PreviewDataService.php
@@ -41,7 +41,7 @@ final readonly class PreviewDataService implements PreviewDataServiceInterface
     use ConfigurationPermissionTrait;
     use CurrentUserResolverTrait;
 
-    private const int MAX_FILE_SIZE = 10485760; // 10MB
+    private const int MAX_FILE_SIZE = 52428800; // 50MB
 
     public function __construct(
         private PreviewHydratorInterface $previewHydrator,

--- a/src/Service/Studio/PreviewDataService.php
+++ b/src/Service/Studio/PreviewDataService.php
@@ -43,6 +43,12 @@ final readonly class PreviewDataService implements PreviewDataServiceInterface
 
     private const int MAX_FILE_SIZE = 52428800; // 50MB
 
+    private const int MAX_FULL_LOAD_FILE_SIZE = 10485760; // 10MB
+
+    // interpreters that still load the entire preview file into memory,
+    // so they keep the lower file size limit
+    private const array FULL_LOAD_INTERPRETERS = ['json', 'xml', 'sql'];
+
     public function __construct(
         private PreviewHydratorInterface $previewHydrator,
         private PreviewService $previewService,
@@ -66,8 +72,12 @@ final readonly class PreviewDataService implements PreviewDataServiceInterface
                 throw new EnvironmentException('Uploaded file is empty');
             }
 
-            if ($file->getSize() > self::MAX_FILE_SIZE) {
-                throw new MaxFileSizeExceededException(self::MAX_FILE_SIZE);
+            $maxFileSize = $this->getMaxPreviewFileSize(
+                $this->configurationPreparationService->prepareConfiguration($name, null)
+            );
+
+            if ($file->getSize() > $maxFileSize) {
+                throw new MaxFileSizeExceededException($maxFileSize);
             }
 
             $user = $this->resolveCurrentUser();
@@ -110,8 +120,10 @@ final readonly class PreviewDataService implements PreviewDataServiceInterface
                 throw new EnvironmentException('File is empty');
             }
 
-            if (filesize($sourcePath) > self::MAX_FILE_SIZE) {
-                throw new MaxFileSizeExceededException(self::MAX_FILE_SIZE);
+            $maxFileSize = $this->getMaxPreviewFileSize($preparedConfig);
+
+            if (filesize($sourcePath) > $maxFileSize) {
+                throw new MaxFileSizeExceededException($maxFileSize);
             }
 
             $user = $this->resolveCurrentUser();
@@ -120,6 +132,17 @@ final readonly class PreviewDataService implements PreviewDataServiceInterface
         } finally {
             $loader->cleanup();
         }
+    }
+
+    private function getMaxPreviewFileSize(array $preparedConfig): int
+    {
+        $interpreterType = $preparedConfig['interpreterConfig']['type'] ?? null;
+
+        if (in_array($interpreterType, self::FULL_LOAD_INTERPRETERS, true)) {
+            return self::MAX_FULL_LOAD_FILE_SIZE;
+        }
+
+        return self::MAX_FILE_SIZE;
     }
 
     public function loadPreviewData(


### PR DESCRIPTION
## Problem

Closes https://github.com/pimcore/platform-version/issues/252

Once a preview file is stored for a Data Importer configuration, opening that configuration in Studio calls `previewData()` on the interpreter for **every** config GET (`ConfigurationDetailHydrator` -> `PreviewHydrator::loadAvailableColumnHeaders`), as well as for the load-preview, column-headers and transformation-result endpoints.

`XlsxFileInterpreter::previewData()` loads the entire workbook via `IOFactory::createReaderForFile()->load()` and converts the whole sheet with `toArray()`, even though it only needs the header row and a single data row. With a real-world 7.5 MB xlsx (4,868 rows x 408 columns) this peaks at **~1.1 GB** of memory. On a default 512M `memory_limit` every one of those endpoints dies with `OutOfMemoryError`, which means the configuration can never be opened again in Studio once a preview has been copied/uploaded — the whole config panel 500s on open.

Two secondary issues made this worse to diagnose:

- `AssetLoader::cleanup()` calls `unlink()` unguarded from a `finally` block. When `loadData()` or a validation check throws, the temporary file property is unset and the resulting `unlink(): No such file or directory` warning masks the original exception in the API response.
- `PreviewDataService::MAX_FILE_SIZE` is hard-coded to 10 MB, which realistic ERP/PIM export files easily exceed.

## Fix

- `previewData()` now determines the row count via `$reader->listWorksheetInfo()` (streams the XML without loading cells) and then loads only the header row and the requested data row using a new `PreviewRowsReadFilter` (`IReadFilter`) together with `setLoadSheetsOnly()`. Output (column labels, preview row, `readRecordNumber` clamping) is unchanged. Peak memory for the file above drops from ~1.1 GB to **~85 MB**.
- `AssetLoader::cleanup()` only unlinks when the temporary file exists, so the original exception surfaces instead of the unlink warning.
- Preview max file size raised to 50 MB for formats whose previews are read row-by-row; json/xml/sql previews still load the whole file and keep the 10 MB cap.

Verified against a 10.5 MB xlsx (499 columns): config GET, load-preview, column-headers, transformation-result and copy-preview all succeed within a 512M memory limit.
