### PR TITLE
[Bug] Allow missing fallbackPath in location strategies

### DIFF
--- a/src/Resolver/Location/FindOrCreateFolderStrategy.php
+++ b/src/Resolver/Location/FindOrCreateFolderStrategy.php
@@ -25,7 +25,7 @@ final class FindOrCreateFolderStrategy implements LocationStrategyInterface
 {
     private mixed $dataSourceIndex;
 
-    private string $fallbackPath;
+    private ?string $fallbackPath = null;
 
     public function __construct(private readonly DataObjectLoader $dataObjectLoader)
     {

--- a/src/Resolver/Location/FindParentStrategy.php
+++ b/src/Resolver/Location/FindParentStrategy.php
@@ -36,7 +36,7 @@ final class FindParentStrategy implements LocationStrategyInterface
 
     private string $findStrategy;
 
-    private string $fallbackPath;
+    private ?string $fallbackPath = null;
 
     private mixed $attributeDataObjectClassId;
 

--- a/tests/unit/LocationStrategyFallbackPathTest.php
+++ b/tests/unit/LocationStrategyFallbackPathTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types=1);
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataImporterBundle\Resolver\Location\FindOrCreateFolderStrategy;
+use Pimcore\Bundle\DataImporterBundle\Resolver\Location\FindParentStrategy;
+use Pimcore\Bundle\DataImporterBundle\Tool\DataObjectLoader;
+
+class LocationStrategyFallbackPathTest extends Unit
+{
+    protected $tester;
+
+    public function provideStrategies(): array
+    {
+        return [
+            [FindParentStrategy::class],
+            [FindOrCreateFolderStrategy::class],
+        ];
+    }
+
+    /**
+     * @dataProvider provideStrategies
+     */
+    public function testMissingFallbackPathIsAllowed(string $strategyClass): void
+    {
+        $strategy = new $strategyClass(new DataObjectLoader());
+        $fallbackPath = (new \ReflectionObject($strategy))->getProperty('fallbackPath');
+        $fallbackPath->setAccessible(true);
+
+        $strategy->setSettings([
+            'dataSourceIndex' => 1,
+            'findStrategy' => 'path',
+        ]);
+
+        self::assertNull($fallbackPath->getValue($strategy));
+    }
+
+    /**
+     * @dataProvider provideStrategies
+     */
+    public function testFallbackPathIsAssigned(string $strategyClass): void
+    {
+        $strategy = new $strategyClass(new DataObjectLoader());
+        $fallbackPath = (new \ReflectionObject($strategy))->getProperty('fallbackPath');
+        $fallbackPath->setAccessible(true);
+
+        $strategy->setSettings([
+            'dataSourceIndex' => 1,
+            'findStrategy' => 'path',
+            'fallbackPath' => '/fallback',
+        ]);
+
+        self::assertSame('/fallback', $fallbackPath->getValue($strategy));
+    }
+}

--- a/tests/unit/LocationStrategyFallbackPathTest.php
+++ b/tests/unit/LocationStrategyFallbackPathTest.php
@@ -2,6 +2,7 @@
 
 namespace Pimcore\Bundle\DataImporterBundle\Tests\unit;
 
+use Closure;
 use Codeception\Test\Unit;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Location\FindOrCreateFolderStrategy;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Location\FindParentStrategy;
@@ -25,15 +26,13 @@ class LocationStrategyFallbackPathTest extends Unit
     public function testMissingFallbackPathIsAllowed(string $strategyClass): void
     {
         $strategy = new $strategyClass(new DataObjectLoader());
-        $fallbackPath = (new \ReflectionObject($strategy))->getProperty('fallbackPath');
-        $fallbackPath->setAccessible(true);
 
         $strategy->setSettings([
             'dataSourceIndex' => 1,
             'findStrategy' => 'path',
         ]);
 
-        self::assertNull($fallbackPath->getValue($strategy));
+        static::assertNull($this->readFallbackPath($strategy));
     }
 
     /**
@@ -42,8 +41,6 @@ class LocationStrategyFallbackPathTest extends Unit
     public function testFallbackPathIsAssigned(string $strategyClass): void
     {
         $strategy = new $strategyClass(new DataObjectLoader());
-        $fallbackPath = (new \ReflectionObject($strategy))->getProperty('fallbackPath');
-        $fallbackPath->setAccessible(true);
 
         $strategy->setSettings([
             'dataSourceIndex' => 1,
@@ -51,6 +48,13 @@ class LocationStrategyFallbackPathTest extends Unit
             'fallbackPath' => '/fallback',
         ]);
 
-        self::assertSame('/fallback', $fallbackPath->getValue($strategy));
+        static::assertSame('/fallback', $this->readFallbackPath($strategy));
+    }
+
+    private function readFallbackPath(object $strategy): ?string
+    {
+        return Closure::bind(function () {
+            return $this->fallbackPath;
+        }, $strategy, $strategy::class)();
     }
 }


### PR DESCRIPTION
## Problem

`FindParentStrategy::setSettings()` assigns `$settings['fallbackPath'] ?? null` to the `string`-typed `$fallbackPath` property. When no fallback path is configured, this crashes with:

```
Cannot assign null to property Pimcore\Bundle\DataImporterBundle\Resolver\Location\FindParentStrategy::$fallbackPath of type string
```

`FindOrCreateFolderStrategy` has the identical pattern and crashes the same way.

## Fix

Make `$fallbackPath` nullable (`?string`, defaulting to `null`) in both strategies. Downstream usage is already null-safe — both classes only use the property in a truthy guard (`if (... && $this->fallbackPath)`) before calling `DataObject::getByPath()`. Behavior with a configured fallback path is unchanged.

`$attributeLanguage` (mentioned in the report) was already fixed by #640.

Includes a regression test covering both strategies with and without `fallbackPath`.

Fixes internal issue PEES-1233 / https://github.com/pimcore/service-operations/issues/876

🤖 Generated with [Claude Code](https://claude.com/claude-code)