### PR TITLE
Fix: don't treat empty identifier column as missing (PEES-1236)

### DIFF
--- a/src/Resolver/Load/AbstractLoad.php
+++ b/src/Resolver/Load/AbstractLoad.php
@@ -100,6 +100,10 @@ abstract class AbstractLoad implements LoadStrategyInterface
      */
     public function extractIdentifierFromData(array $inputData)
     {
-        return $inputData[$this->dataSourceIndex] ?? throw new \InvalidArgumentException('Identifier not set.');
+        if (!array_key_exists($this->dataSourceIndex, $inputData)) {
+            throw new \InvalidArgumentException('Identifier not set.');
+        }
+
+        return $inputData[$this->dataSourceIndex];
     }
 }

--- a/src/Resolver/Load/AbstractLoad.php
+++ b/src/Resolver/Load/AbstractLoad.php
@@ -90,7 +90,12 @@ abstract class AbstractLoad implements LoadStrategyInterface
      */
     public function loadElement(array $inputData): ?ElementInterface
     {
-        return $this->loadElementByIdentifier($this->extractIdentifierFromData($inputData));
+        $identifier = $this->extractIdentifierFromData($inputData);
+        if ($identifier === null) {
+            return null;
+        }
+
+        return $this->loadElementByIdentifier($identifier);
     }
 
     /**

--- a/tests/unit/AbstractLoadTest.php
+++ b/tests/unit/AbstractLoadTest.php
@@ -3,7 +3,9 @@
 namespace Pimcore\Bundle\DataImporterBundle\Tests\unit;
 
 use Codeception\Test\Unit;
+use Doctrine\DBAL\Connection;
 use Pimcore\Bundle\DataImporterBundle\Resolver\Load\IdStrategy;
+use Pimcore\Bundle\DataImporterBundle\Tool\DataObjectLoader;
 
 class AbstractLoadTest extends Unit
 {
@@ -11,11 +13,8 @@ class AbstractLoadTest extends Unit
 
     private function createStrategy(mixed $dataSourceIndex): IdStrategy
     {
-        $strategy = (new \ReflectionClass(IdStrategy::class))->newInstanceWithoutConstructor();
-
-        $dataSourceIndexProperty = (new \ReflectionObject($strategy))->getProperty('dataSourceIndex');
-        $dataSourceIndexProperty->setAccessible(true);
-        $dataSourceIndexProperty->setValue($strategy, $dataSourceIndex);
+        $strategy = new IdStrategy($this->createMock(Connection::class), new DataObjectLoader());
+        $strategy->setSettings(['dataSourceIndex' => $dataSourceIndex]);
 
         return $strategy;
     }
@@ -24,14 +23,14 @@ class AbstractLoadTest extends Unit
     {
         $strategy = $this->createStrategy(0);
 
-        self::assertSame('abc', $strategy->extractIdentifierFromData([0 => 'abc']));
+        static::assertSame('abc', $strategy->extractIdentifierFromData([0 => 'abc']));
     }
 
     public function testReturnsNullWhenIdentifierColumnIsEmpty(): void
     {
         $strategy = $this->createStrategy(0);
 
-        self::assertNull($strategy->extractIdentifierFromData([0 => null]));
+        static::assertNull($strategy->extractIdentifierFromData([0 => null]));
     }
 
     public function testThrowsExceptionWhenIdentifierColumnIsMissing(): void
@@ -48,6 +47,6 @@ class AbstractLoadTest extends Unit
     {
         $strategy = $this->createStrategy(0);
 
-        self::assertNull($strategy->loadElement([0 => null]));
+        static::assertNull($strategy->loadElement([0 => null]));
     }
 }

--- a/tests/unit/AbstractLoadTest.php
+++ b/tests/unit/AbstractLoadTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataImporterBundle\Resolver\Load\IdStrategy;
+
+class AbstractLoadTest extends Unit
+{
+    protected $tester;
+
+    private function createStrategy(mixed $dataSourceIndex): IdStrategy
+    {
+        $strategy = (new \ReflectionClass(IdStrategy::class))->newInstanceWithoutConstructor();
+
+        $dataSourceIndexProperty = (new \ReflectionObject($strategy))->getProperty('dataSourceIndex');
+        $dataSourceIndexProperty->setAccessible(true);
+        $dataSourceIndexProperty->setValue($strategy, $dataSourceIndex);
+
+        return $strategy;
+    }
+
+    public function testReturnsValueWhenIdentifierIsSet(): void
+    {
+        $strategy = $this->createStrategy(0);
+
+        self::assertSame('abc', $strategy->extractIdentifierFromData([0 => 'abc']));
+    }
+
+    public function testReturnsNullWhenIdentifierColumnIsEmpty(): void
+    {
+        $strategy = $this->createStrategy(0);
+
+        self::assertNull($strategy->extractIdentifierFromData([0 => null]));
+    }
+
+    public function testThrowsExceptionWhenIdentifierColumnIsMissing(): void
+    {
+        $strategy = $this->createStrategy(0);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Identifier not set.');
+
+        $strategy->extractIdentifierFromData([]);
+    }
+}

--- a/tests/unit/AbstractLoadTest.php
+++ b/tests/unit/AbstractLoadTest.php
@@ -43,4 +43,11 @@ class AbstractLoadTest extends Unit
 
         $strategy->extractIdentifierFromData([]);
     }
+
+    public function testLoadElementReturnsNullForEmptyIdentifierInsteadOfTypeError(): void
+    {
+        $strategy = $this->createStrategy(0);
+
+        self::assertNull($strategy->loadElement([0 => null]));
+    }
 }


### PR DESCRIPTION
## Summary
- `AbstractLoad::extractIdentifierFromData()` used the `??` operator, which throws `InvalidArgumentException` both when the configured column is absent **and** when its value is `null` — exactly what an empty Excel cell produces, wrongly blocking the create path during data import.
- Replaced it with an `array_key_exists()` check so only a genuinely missing column throws; a present-but-empty identifier now correctly returns `null`.
- Added `tests/unit/AbstractLoadTest.php` covering: value set, value `null` (empty cell), key missing.

Resolves pimcore/service-operations#877
Fixes https://pimcore.atlassian.net/browse/PEES-1236

## Test plan
- [x] New unit test added, both branches (null value vs. missing key) exercised
- [ ] CI (Codeception) run — not executed locally, needs the full Pimcore bootstrap