### PR TITLE
Fix PHPStan: drop dead null-coalesce in XlsxFileInterpreter::getWorksheetInfo()

### DIFF
--- a/src/DataSource/Interpreter/XlsxFileInterpreter.php
+++ b/src/DataSource/Interpreter/XlsxFileInterpreter.php
@@ -188,10 +188,10 @@ final class XlsxFileInterpreter extends AbstractInterpreter
         $reader = IOFactory::createReaderForFile($path);
 
         foreach ($reader->listWorksheetInfo($path) as $worksheetInfo) {
-            if (($worksheetInfo['worksheetName'] ?? null) === $this->sheetName) {
+            if ($worksheetInfo['worksheetName'] === $this->sheetName) {
                 return [
-                    'totalRows' => (int)($worksheetInfo['totalRows'] ?? 0),
-                    'lastColumnLetter' => (string)($worksheetInfo['lastColumnLetter'] ?? 'A'),
+                    'totalRows' => $worksheetInfo['totalRows'],
+                    'lastColumnLetter' => $worksheetInfo['lastColumnLetter'],
                 ];
             }
         }


### PR DESCRIPTION
## Problem

After #661 merged, static analysis on `2026.2` started failing (https://github.com/pimcore/data-importer/actions/runs/31784862881) across all PHPStan matrix jobs:

```
Offset 'worksheetName' on array{worksheetName: string, lastColumnLetter: string, lastColumnIndex: int, totalRows: int, totalColumns: int, sheetState: string} on left side of ?? always exists and is not nullable.
Offset 'totalRows' on array{...} on left side of ?? always exists and is not nullable.
Offset 'lastColumnLetter' on array{...} on left side of ?? always exists and is not nullable.
```

`PhpOffice\PhpSpreadsheet\Reader\IReader::listWorksheetInfo()` is typed to always return `worksheetName`, `lastColumnLetter`, and `totalRows` as non-nullable. The `?? null` / `?? 0` / `?? 'A'` fallbacks added in `XlsxFileInterpreter::getWorksheetInfo()` in #661 are therefore unreachable dead code, which PHPStan (highest level) flags.

## Fix

Drop the dead fallbacks and the now-unnecessary casts. No behavior change — these branches were never reachable.

## Testing

No regression test added: this is a static-analysis-only fix with no functional change, so there is nothing to regression-test. Not verified locally (no PHP/Composer/PHPStan available in the environment this was prepared in) — CI on this PR is the verification.