### PR TITLE
[Studio] Fix mapping rows showing a neighbouring row's values after add/remove

### DIFF
--- a/assets/studio/js/src/modules/data-importer/components/tabs/steps/mapping-step/mapping-item/mapping-item-with-filter.tsx
+++ b/assets/studio/js/src/modules/data-importer/components/tabs/steps/mapping-step/mapping-item/mapping-item-with-filter.tsx
@@ -8,9 +8,9 @@
  *  @license    Pimcore Open Core License (POCL)
  */
 
-import React from 'react'
+import React, { useRef } from 'react'
 import { Form } from '@pimcore/studio-ui-bundle/components'
-import { type MappingConfigItem } from '../../../../../types'
+import { type DataImporterFormValues, type MappingConfigItem } from '../../../../../types'
 import { useMappingItemContext } from '../mapping-item-context'
 import { useStyles } from '../mapping-step.styles'
 import { MappingDropZone } from './mapping-drop-zone'
@@ -67,9 +67,25 @@ export const MappingItemWithFilter = React.memo(({
   const { configName, classId, columnHeaderOptions, attributesMap } = useMappingItemContext()
   const { styles, cx } = useStyles()
 
-  // Watch only this item's index in mappingConfig. Selector is O(1) by path.
-  const itemByIndex = Form.useWatch(['mappingConfig', fieldIndex]) as MappingConfigItem | undefined
-  const item: MappingConfigItem = itemByIndex ?? {}
+  const form = Form.useFormInstance()
+
+  // `fieldIndex` shifts whenever a mapping is inserted or removed above this one, but
+  // `Form.useWatch` registers its watcher exactly once — rc-field-form explicitly does not
+  // support a dynamic name path. A plain `useWatch(['mappingConfig', fieldIndex])` therefore
+  // keeps the value it read for the *previous* index: right after an add/remove every row
+  // below the change renders a neighbouring row's label, sources and data target.
+  //
+  // Subscribing through a selector that reads the index from a ref keeps that single
+  // registration valid for value edits, and the value itself is read from the form during
+  // render so it always belongs to the CURRENT index. Structural changes always re-render
+  // this component (the field's `name` changes), so the fresh read cannot go stale.
+  const fieldIndexRef = useRef(fieldIndex)
+  fieldIndexRef.current = fieldIndex
+
+  Form.useWatch((values: DataImporterFormValues) => values?.mappingConfig?.[fieldIndexRef.current])
+
+  const item: MappingConfigItem =
+    (form.getFieldValue(['mappingConfig', fieldIndex]) as MappingConfigItem | undefined) ?? {}
 
   const dataSourceIndex = item.dataSourceIndex
   const isHidden = activeFilter !== null && !(dataSourceIndex ?? []).includes(activeFilter)

--- a/assets/studio/js/src/modules/data-importer/components/tabs/steps/mapping-step/mapping-step.tsx
+++ b/assets/studio/js/src/modules/data-importer/components/tabs/steps/mapping-step/mapping-step.tsx
@@ -214,33 +214,32 @@ export const MappingStep = React.memo(({ configName, isActive }: MappingStepProp
       })
     }
 
-    setActiveFilter((currentFilter) => {
-      if (currentFilter !== null) {
-        const currentItems = getMappingConfig()
-        const remaining = currentItems.filter((_, i) => i !== index)
-        const stillReferenced = remaining.some((item) =>
-          (item.dataSourceIndex ?? []).includes(currentFilter)
-        )
-        if (!stillReferenced) {
-          remove(index)
-          if (debugEnabled) {
-            console.debug('[DI][Action] remove mapping + clear filter', {
-              index,
-              clearedFilter: currentFilter
-            })
-          }
-          return null
-        }
+    // Read the filter from the ref instead of a state updater: `remove()` mutates the form
+    // store, and a state updater must stay pure — React invokes it twice in StrictMode,
+    // which would delete two mappings for a single click.
+    const currentFilter = activeFilterRef.current
+    let clearedFilter: string | null = null
+
+    if (currentFilter !== null) {
+      const remaining = getMappingConfig().filter((_, i) => i !== index)
+      const stillReferenced = remaining.some((item) =>
+        (item.dataSourceIndex ?? []).includes(currentFilter)
+      )
+      if (!stillReferenced) {
+        clearedFilter = currentFilter
+        setActiveFilter(null)
       }
-      remove(index)
-      if (debugEnabled) {
-        console.debug('[DI][Action] remove mapping done', {
-          index,
-          keptFilter: currentFilter
-        })
-      }
-      return currentFilter
-    })
+    }
+
+    remove(index)
+
+    if (debugEnabled) {
+      console.debug('[DI][Action] remove mapping done', {
+        index,
+        clearedFilter,
+        keptFilter: clearedFilter === null ? currentFilter : null
+      })
+    }
   }, [getMappingConfig])
 
   const createMappingItemFromSource = useCallback((dataIndex: string, label: string): MappingConfigItem => {


### PR DESCRIPTION
### Bug

In the Studio Data Importer mapping step, the mapping rows show the wrong values as soon as the list structure changes:

* **Adding a mapping** — the new mapping is inserted at the top, but the row *below* it also renders the new mapping's label, source column and data target.
* **Removing a mapping** — every row below the removed one displays the values of the row underneath it; the last row ends up empty.

It is a display-only problem — the form store stays correct, so nothing wrong is saved and the display heals itself as soon as any value changes again — but it makes configuring a mapping very confusing.

#### Steps to reproduce

1. Open a Data Objects importer, run a preview import so source columns are available, and configure at least three mappings with recognisable labels.
2. Open the *Mapping* step and expand the first two mappings.
3. Click **New**, pick a source column and confirm.
4. The new mapping appears at the top **and** the row below it shows the same label, source and (empty) data target. In the sources panel on the left the picked column still shows a usage count of 1, confirming only one mapping actually uses it.
5. Delete the mapping again: the first row now shows the *second* mapping's values, and so on down the list.

Verified on 2026.1 and reproducible on `2026.2` / `2026.x` (the file is identical on all three).

### Cause

`MappingItemWithFilter` watched its own mapping with a **dynamic** name path:

```tsx
const itemByIndex = Form.useWatch(['mappingConfig', fieldIndex]) as MappingConfigItem | undefined
```

`rc-field-form`'s `useWatch` registers its watcher exactly once — the effect's dependency list is `[isValidForm]` — and warns in development that this is unsupported: ``` `useWatch` is not support dynamic `namePath`. Please provide static instead. ```

`Form.List` keeps `field.key` stable but shifts `field.name` (the array index) when an item is inserted or removed, and `notifyWatch` fires **synchronously**, before React re-renders. So on `add(item, 0)` the row that was at index 0 still has `fieldIndex === 0` at notification time, reads `mappingConfig[0]` — the *new* item — and stores it. The subsequent re-render hands it `fieldIndex === 1`, but nothing re-reads the value, so the stale one stays on screen until the next store change. `remove(index)` shifts the values of all rows below it the same way.

### Fix

Subscribe through a selector that reads the index from a ref — that keeps the single registration valid for value edits at a stable index — and read the value from the form **during render**, so it always belongs to the current index:

```tsx
const fieldIndexRef = useRef(fieldIndex)
fieldIndexRef.current = fieldIndex

Form.useWatch((values: DataImporterFormValues) => values?.mappingConfig?.[fieldIndexRef.current])

const item: MappingConfigItem =
  (form.getFieldValue(['mappingConfig', fieldIndex]) as MappingConfigItem | undefined) ?? {}
```

Structural changes always re-render this component (`field.name` changes, so `MappingsPanelContent` rebuilds its item list), which means the fresh read cannot go stale — a missed or mis-targeted notification can now only cost one extra render, never show a wrong value.

Watching the whole `mappingConfig` array instead would also be correct but would re-render and re-`JSON.stringify` every row on every keystroke, undoing the existing per-item subscription optimisation in `MappingsPanel` / `MappingsPanelContent`.

### Second commit (independent, easy to drop)

`handleRemoveItem` called `remove(index)` from inside the `setActiveFilter` updater. State updaters must be pure, and React invokes them twice under `StrictMode` (which Studio enables), so in a development build one click on the delete icon removed **two** mappings. The current filter is now read from the existing `activeFilterRef`, with the filter reset and the removal both performed outside the updater.

### Notes

* Source-only change: `assets/studio` has no jest/vitest setup, so there is no automated test to add here, and the built assets under `src/Resources/public/studio/build/` are left to the automatic frontend build (the `commit-build` job is skipped for fork PRs).
* Verified manually against a 2026.1 installation with the patched bundle rebuilt: adding a mapping no longer touches the row below it, and deleting one leaves the remaining rows intact.

### Tracking issue

Fixes pimcore/platform-version#337
