### PR TITLE
[Telemetry] Report Data Importer setup as usage.data_importer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
     "mtdowling/jmespath.php": "^2.8",
     "nesbot/carbon": "^2.72 || ^3.8.4",
     "phpoffice/phpspreadsheet": "^4.3 || ^5.1",
-    "pimcore/data-hub": "^2026.1.3",
-    "pimcore/pimcore": "^2026.1",
+    "pimcore/data-hub": "^2026.3",
+    "pimcore/pimcore": "^2026.3",
     "pimcore/studio-backend-bundle": "^2026.1",
     "pimcore/studio-ui-bundle": "^2026.2.6",
     "webmozarts/console-parallelization": "^1.2.0 || ^2.0.0"

--- a/src/DependencyInjection/PimcoreDataImporterExtension.php
+++ b/src/DependencyInjection/PimcoreDataImporterExtension.php
@@ -41,6 +41,8 @@ final class PimcoreDataImporterExtension extends Extension implements PrependExt
 
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.yml');
+        // usage.* telemetry provider; core extension point guaranteed by the composer constraint
+        $loader->load('telemetry.yaml');
         $loader->load('studio_backend.yaml');
 
         $definition = $container->getDefinition(DataImporterHandler::class);

--- a/src/Resources/config/telemetry.yaml
+++ b/src/Resources/config/telemetry.yaml
@@ -1,0 +1,16 @@
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    # usage.* provider; the core telemetry extension point is guaranteed by the pimcore/pimcore
+    # constraint in composer.json, so it is loaded unconditionally.
+    #
+    # Import configurations are Data Hub configurations of this bundle's adapter type, read through Data
+    # Hub's shared memoised service rather than a table.
+    Pimcore\Bundle\DataImporterBundle\Telemetry\DataHubImportConfigurations: ~
+
+    Pimcore\Bundle\DataImporterBundle\Telemetry\ImportConfigurationsInterface:
+        '@Pimcore\Bundle\DataImporterBundle\Telemetry\DataHubImportConfigurations'
+
+    Pimcore\Bundle\DataImporterBundle\Telemetry\DataImporterUsageProvider: ~

--- a/src/Telemetry/DataHubImportConfigurations.php
+++ b/src/Telemetry/DataHubImportConfigurations.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Telemetry;
+
+use Pimcore\Bundle\DataHubBundle\Telemetry\DataHubConfigurationUsage;
+
+/**
+ * Import configurations are Data Hub configurations of the importer's adapter type, so the question is
+ * put to Data Hub's shared, memoised read - the same instance the five Data Hub packages already use,
+ * which means this costs no additional read and inherits the location-aware handling (settings store or
+ * Symfony config files) that a direct table query would get wrong.
+ *
+ * @internal
+ */
+final readonly class DataHubImportConfigurations implements ImportConfigurationsInterface
+{
+    /**
+     * The adapter type this bundle registers with Data Hub.
+     */
+    private const ADAPTER_TYPE = 'dataImporterDataObject';
+
+    public function __construct(
+        private DataHubConfigurationUsage $configurations,
+    ) {
+    }
+
+    public function hasActive(): ?bool
+    {
+        return $this->configurations->hasActiveOfType([self::ADAPTER_TYPE]);
+    }
+}

--- a/src/Telemetry/DataImporterUsageProvider.php
+++ b/src/Telemetry/DataImporterUsageProvider.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Telemetry;
+
+use Pimcore\Telemetry\Usage\BundleUsageProviderInterface;
+
+/**
+ * Is the Data Importer set up, or merely installed?
+ *
+ * "Used" means at least one import configuration is **active** - the L3 question every `usage.*` key
+ * answers. Active rather than merely existing: a disabled import is one somebody built and then switched
+ * off, which is the opposite of adoption.
+ *
+ * Whether an import has actually run is the L4 fact; it lives in
+ * `bundle_data_hub_data_importer_last_execution` and is deliberately not what this key reports, so the
+ * namespace stays comparable bundle to bundle.
+ *
+ * Content-never: a boolean. Configuration names are never emitted.
+ *
+ * @internal
+ */
+final readonly class DataImporterUsageProvider implements BundleUsageProviderInterface
+{
+    public function __construct(
+        private ImportConfigurationsInterface $configurations,
+    ) {
+    }
+
+    public function getBundleKey(): string
+    {
+        return 'data_importer';
+    }
+
+    public function isUsed(): ?bool
+    {
+        return $this->configurations->hasActive();
+    }
+}

--- a/src/Telemetry/ImportConfigurationsInterface.php
+++ b/src/Telemetry/ImportConfigurationsInterface.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Telemetry;
+
+/**
+ * The seam between the usage provider and Data Hub's configuration store, where import configurations live.
+ *
+ * @internal
+ */
+interface ImportConfigurationsInterface
+{
+    /**
+     * @return bool|null null when the configuration store could not be read - unknown, not unused
+     */
+    public function hasActive(): ?bool;
+}

--- a/tests/unit/Telemetry/DataHubImportConfigurationsTest.php
+++ b/tests/unit/Telemetry/DataHubImportConfigurationsTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit\Telemetry;
+
+use Codeception\Test\Unit;
+use function json_encode;
+use Pimcore\Bundle\DataHubBundle\Configuration\Dao;
+use Pimcore\Bundle\DataHubBundle\Telemetry\DataHubConfigurationUsage;
+use Pimcore\Bundle\DataImporterBundle\Telemetry\DataHubImportConfigurations;
+use Pimcore\Model\Tool\SettingsStore;
+use ReflectionProperty;
+use Symfony\Component\Yaml\Yaml;
+use function time;
+use function uniqid;
+
+/**
+ * The adapter over Data Hub's shared configuration read, exercised against the real store rather than a
+ * double: a configuration is seeded exactly as Data Hub's own Dao stores it, read back through
+ * {@see \Pimcore\Bundle\DataHubBundle\Configuration::getList()}, and the adapter's answer checked.
+ *
+ * This is what pins the adapter type. {@see DataHubImportConfigurations} names `dataImporterDataObject`,
+ * and only a configuration stored under exactly that type may make it true; a typo or drift there fails
+ * these tests, while the provider tests, which mock the seam, would still pass.
+ *
+ * DB-backed: the unit suite connects the database. Every seeded entry carries a unique name and is removed
+ * again in {@see _after()}.
+ */
+class DataHubImportConfigurationsTest extends Unit
+{
+    private const SETTINGS_STORE_SCOPE = 'pimcore_data_hub';
+
+    private const IMPORTER_TYPE = 'dataImporterDataObject';
+
+    /**
+     * @var list<string>
+     */
+    private array $seeded = [];
+
+    protected function _before(): void
+    {
+        $this->forgetCachedList();
+    }
+
+    protected function _after(): void
+    {
+        foreach ($this->seeded as $name) {
+            SettingsStore::delete($name, self::SETTINGS_STORE_SCOPE);
+        }
+        $this->seeded = [];
+        $this->forgetCachedList();
+    }
+
+    public function testAnActiveImportConfigurationIsUsed(): void
+    {
+        $this->seed(self::IMPORTER_TYPE, active: true);
+
+        $this->assertTrue($this->adapter()->hasActive());
+    }
+
+    /**
+     * Active rather than merely existing: a disabled import is one somebody built and then switched off.
+     */
+    public function testAnInactiveImportConfigurationIsNotUsed(): void
+    {
+        $this->seed(self::IMPORTER_TYPE, active: false);
+
+        $used = $this->adapter()->hasActive();
+
+        $this->assertFalse($used);
+        $this->assertNotNull($used);
+    }
+
+    /**
+     * Data Hub keeps every adapter's configurations in one store; another adapter's active configuration
+     * is not an import.
+     */
+    public function testAnActiveConfigurationOfAnotherAdapterIsNotAnImport(): void
+    {
+        $this->seed('graphql', active: true);
+
+        $this->assertFalse($this->adapter()->hasActive());
+    }
+
+    /**
+     * The type these tests seed is the one this bundle registers with Data Hub, so the adapter, the tests
+     * and the registration cannot drift apart unnoticed.
+     */
+    public function testTheImporterTypeIsTheOneRegisteredWithDataHub(): void
+    {
+        $registered = Yaml::parseFile(__DIR__ . '/../../../src/Resources/config/pimcore/config.yml');
+
+        $this->assertArrayHasKey(self::IMPORTER_TYPE, $registered['pimcore_data_hub']['supported_types']);
+    }
+
+    private function adapter(): DataHubImportConfigurations
+    {
+        // A fresh instance each time: DataHubConfigurationUsage memoises its read for the lifetime of the
+        // service, which is one snapshot run.
+        return new DataHubImportConfigurations(new DataHubConfigurationUsage());
+    }
+
+    /**
+     * Stores a configuration the way Data Hub's Dao does: the configuration array itself, under its name,
+     * in the `pimcore_data_hub` settings-store scope. Only `general` matters to the read under test.
+     */
+    private function seed(string $type, bool $active): void
+    {
+        $name = uniqid('telemetry_test_');
+        $now = time();
+        $data = [
+            'general' => [
+                'active' => $active,
+                'type' => $type,
+                'name' => $name,
+                'path' => '',
+                'group' => '',
+                'createDate' => $now,
+                'modificationDate' => $now,
+            ],
+        ];
+
+        SettingsStore::set(
+            $name,
+            json_encode($data, JSON_THROW_ON_ERROR),
+            SettingsStore::TYPE_STRING,
+            self::SETTINGS_STORE_SCOPE
+        );
+        $this->seeded[] = $name;
+    }
+
+    /**
+     * Data Hub's Dao memoises the configuration list in a private static for the lifetime of the process -
+     * right for one snapshot run, wrong for a test that seeds between cases.
+     */
+    private function forgetCachedList(): void
+    {
+        (new ReflectionProperty(Dao::class, '_config'))->setValue(null, null);
+    }
+}

--- a/tests/unit/Telemetry/DataHubImportConfigurationsTest.php
+++ b/tests/unit/Telemetry/DataHubImportConfigurationsTest.php
@@ -14,114 +14,93 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\DataImporterBundle\Tests\unit\Telemetry;
 
+use function array_key_first;
 use Codeception\Test\Unit;
 use function json_encode;
-use Pimcore\Bundle\DataHubBundle\Configuration\Dao;
 use Pimcore\Bundle\DataHubBundle\Telemetry\DataHubConfigurationUsage;
 use Pimcore\Bundle\DataImporterBundle\Telemetry\DataHubImportConfigurations;
 use Pimcore\Model\Tool\SettingsStore;
-use ReflectionProperty;
 use Symfony\Component\Yaml\Yaml;
 use function time;
 use function uniqid;
 
 /**
  * The adapter over Data Hub's shared configuration read, exercised against the real store rather than a
- * double: a configuration is seeded exactly as Data Hub's own Dao stores it, read back through
+ * double: an import configuration is seeded exactly as Data Hub's own Dao stores it, read back through
  * {@see \Pimcore\Bundle\DataHubBundle\Configuration::getList()}, and the adapter's answer checked.
  *
- * This is what pins the adapter type. {@see DataHubImportConfigurations} names `dataImporterDataObject`,
- * and only a configuration stored under exactly that type may make it true; a typo or drift there fails
- * these tests, while the provider tests, which mock the seam, would still pass.
+ * This is what pins the adapter type. The seeded configuration carries the type this bundle registers with
+ * Data Hub - read from the registration itself - and is the only active configuration in the store, so the
+ * adapter reads true only if it asks Data Hub for exactly that type. A typo or drift in
+ * {@see DataHubImportConfigurations} fails this test while the provider tests, which mock the seam, would
+ * still pass.
  *
- * DB-backed: the unit suite connects the database. Every seeded entry carries a unique name and is removed
+ * One store-backed case, deliberately: Data Hub's Dao memoises the configuration list for the lifetime of
+ * the process and offers no reset, so a second listing would still see the first one's store. Whether an
+ * inactive configuration or another adapter's configuration counts is decided in
+ * {@see DataHubConfigurationUsage::hasActiveOfType()}, not here.
+ *
+ * DB-backed: the unit suite connects the database. The seeded entry carries a unique name and is removed
  * again in {@see _after()}.
  */
 class DataHubImportConfigurationsTest extends Unit
 {
     private const SETTINGS_STORE_SCOPE = 'pimcore_data_hub';
 
-    private const IMPORTER_TYPE = 'dataImporterDataObject';
+    private const REGISTRATION = __DIR__ . '/../../../src/Resources/config/pimcore/config.yml';
 
-    /**
-     * @var list<string>
-     */
-    private array $seeded = [];
-
-    protected function _before(): void
-    {
-        $this->forgetCachedList();
-    }
+    private ?string $seeded = null;
 
     protected function _after(): void
     {
-        foreach ($this->seeded as $name) {
-            SettingsStore::delete($name, self::SETTINGS_STORE_SCOPE);
+        if ($this->seeded !== null) {
+            SettingsStore::delete($this->seeded, self::SETTINGS_STORE_SCOPE);
+            $this->seeded = null;
         }
-        $this->seeded = [];
-        $this->forgetCachedList();
     }
 
     public function testAnActiveImportConfigurationIsUsed(): void
     {
-        $this->seed(self::IMPORTER_TYPE, active: true);
+        $this->seedActiveConfiguration($this->registeredAdapterType());
 
-        $this->assertTrue($this->adapter()->hasActive());
+        $adapter = new DataHubImportConfigurations(new DataHubConfigurationUsage());
+
+        $this->assertTrue($adapter->hasActive());
     }
 
     /**
-     * Active rather than merely existing: a disabled import is one somebody built and then switched off.
+     * The seed above is built from the registration; this pins the registration itself to the identifier
+     * Data Hub knows this bundle by.
      */
-    public function testAnInactiveImportConfigurationIsNotUsed(): void
+    public function testThisBundleRegistersTheImporterTypeWithDataHub(): void
     {
-        $this->seed(self::IMPORTER_TYPE, active: false);
-
-        $used = $this->adapter()->hasActive();
-
-        $this->assertFalse($used);
-        $this->assertNotNull($used);
+        $this->assertSame('dataImporterDataObject', $this->registeredAdapterType());
     }
 
     /**
-     * Data Hub keeps every adapter's configurations in one store; another adapter's active configuration
-     * is not an import.
+     * The one adapter type under `pimcore_data_hub.supported_types` in this bundle's own configuration.
      */
-    public function testAnActiveConfigurationOfAnotherAdapterIsNotAnImport(): void
+    private function registeredAdapterType(): string
     {
-        $this->seed('graphql', active: true);
+        $types = Yaml::parseFile(self::REGISTRATION)['pimcore_data_hub']['supported_types'];
 
-        $this->assertFalse($this->adapter()->hasActive());
+        $this->assertCount(1, $types, 'this bundle is expected to register exactly one Data Hub adapter type');
+
+        return (string) array_key_first($types);
     }
 
     /**
-     * The type these tests seed is the one this bundle registers with Data Hub, so the adapter, the tests
-     * and the registration cannot drift apart unnoticed.
+     * Stores an active configuration the way Data Hub's Dao does: the configuration array itself, under
+     * its name, in the `pimcore_data_hub` settings-store scope. Only `general` matters to the read under
+     * test.
      */
-    public function testTheImporterTypeIsTheOneRegisteredWithDataHub(): void
-    {
-        $registered = Yaml::parseFile(__DIR__ . '/../../../src/Resources/config/pimcore/config.yml');
-
-        $this->assertArrayHasKey(self::IMPORTER_TYPE, $registered['pimcore_data_hub']['supported_types']);
-    }
-
-    private function adapter(): DataHubImportConfigurations
-    {
-        // A fresh instance each time: DataHubConfigurationUsage memoises its read for the lifetime of the
-        // service, which is one snapshot run.
-        return new DataHubImportConfigurations(new DataHubConfigurationUsage());
-    }
-
-    /**
-     * Stores a configuration the way Data Hub's Dao does: the configuration array itself, under its name,
-     * in the `pimcore_data_hub` settings-store scope. Only `general` matters to the read under test.
-     */
-    private function seed(string $type, bool $active): void
+    private function seedActiveConfiguration(string $type): void
     {
         $name = uniqid('telemetry_test_');
         $now = time();
         $data = [
             'general' => [
-                'active' => $active,
+                'active' => true,
                 'type' => $type,
                 'name' => $name,
                 'path' => '',
@@ -137,15 +116,6 @@ class DataHubImportConfigurationsTest extends Unit
             SettingsStore::TYPE_STRING,
             self::SETTINGS_STORE_SCOPE
         );
-        $this->seeded[] = $name;
-    }
-
-    /**
-     * Data Hub's Dao memoises the configuration list in a private static for the lifetime of the process -
-     * right for one snapshot run, wrong for a test that seeds between cases.
-     */
-    private function forgetCachedList(): void
-    {
-        (new ReflectionProperty(Dao::class, '_config'))->setValue(null, null);
+        $this->seeded = $name;
     }
 }

--- a/tests/unit/Telemetry/DataImporterUsageProviderTest.php
+++ b/tests/unit/Telemetry/DataImporterUsageProviderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit\Telemetry;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataImporterBundle\Telemetry\DataImporterUsageProvider;
+use Pimcore\Bundle\DataImporterBundle\Telemetry\ImportConfigurationsInterface;
+
+class DataImporterUsageProviderTest extends Unit
+{
+    public function testReportsUnderTheExpectedKey(): void
+    {
+        $this->assertSame('data_importer', $this->provider(true)->getBundleKey());
+    }
+
+    public function testAnActiveImportConfigurationIsUsed(): void
+    {
+        $this->assertTrue($this->provider(true)->isUsed());
+    }
+
+    /**
+     * No active import is a real "installed and not set up" and must not be blurred into unknown.
+     */
+    public function testNoActiveImportIsNotUsedRatherThanUnknown(): void
+    {
+        $used = $this->provider(false)->isUsed();
+
+        $this->assertFalse($used);
+        $this->assertNotNull($used);
+    }
+
+    /**
+     * Data Hub configuration can live in the settings store or in Symfony config files; an unreadable
+     * store must stay unknown, because `false` there would invent an adoption gap for every customer on
+     * the target the read could not reach.
+     */
+    public function testAnUnreadableStoreIsPassedThroughAsUnknown(): void
+    {
+        $this->assertNull($this->provider(null)->isUsed());
+    }
+
+    private function provider(?bool $hasActive): DataImporterUsageProvider
+    {
+        $configurations = $this->createMock(ImportConfigurationsInterface::class);
+        $configurations->method('hasActive')->willReturn($hasActive);
+
+        return new DataImporterUsageProvider($configurations);
+    }
+}


### PR DESCRIPTION
## What

Adds the `usage.data_importer` provider for Pimcore product telemetry: a boolean answering "is the Data Importer **set up**" (L3 – configured), emitted once a day inside the maintenance snapshot.

Set up means **at least one import configuration is active**. Active rather than merely existing: a disabled import is one somebody built and then switched off, which is the opposite of adoption. Whether an import has actually *run* is the exercised (L4) fact, lives in the last-execution table, and is deliberately not what this key reports, so the `usage.*` namespace stays comparable bundle to bundle.

## How

Import configurations are Data Hub configurations of this bundle's adapter type (`dataImporterDataObject`). So the question is put to Data Hub's shared, memoised `DataHubConfigurationUsage` — the same instance the four Data Hub satellites already use (pimcore/data-hub#1138) — via `hasActiveOfType()`.

That is a deliberate choice over a table probe:

- **Zero additional reads.** Data Hub already loads the configuration list once per snapshot for `usage.data_hub` and `datahub.*`; this key is answered from that same pass.
- **Location-aware for free.** `pimcore_data_hub.config_location.data_hub` selects between the settings store and Symfony config files under `var/config/data_hub/`. A probe against `plugin_datahub_config` would report "no configurations" for every customer on the file target — inventing an adoption gap rather than measuring one. Going through the configuration API gets both locations right.

Layout:

- `DataImporterUsageProvider` — the `BundleUsageProviderInterface` implementation; `null` (unknown, key omitted) when the store could not be read, never `false`.
- `ImportConfigurationsInterface` + `DataHubImportConfigurations` — the seam to Data Hub's read, holding the one adapter-type constant.
- `telemetry.yaml`, loaded from the extension. Data Hub is a hard dependency of this bundle, so the wiring is unconditional.

Content-never: one boolean leaves the install. Configuration names are never emitted.

## Verification

- Tests in the **`unit` suite**, where the bundle's Codeception run finds them:
  - `DataImporterUsageProviderTest` (4) — an active import is used; none active is `false`, not unknown; an unreadable store is passed through as `null`; and the key. Mocks the seam.
  - `DataHubImportConfigurationsTest` (2, one DB-backed) — the adapter exercised against the **real** Data Hub read: an import configuration is seeded exactly as Data Hub's Dao stores it (settings-store scope `pimcore_data_hub`), read back through `Configuration::getList()`, and the adapter's answer checked. The seed carries the type this bundle registers under `pimcore_data_hub.supported_types`, read from that registration, and is the only active configuration in the store — so the adapter reads `true` only if it asks Data Hub for exactly that type. A typo or drift in `dataImporterDataObject` fails this test while the mocked provider tests would still pass. The second test pins the registration itself to that identifier. One store-backed case deliberately: Data Hub's Dao memoises the configuration list for the process and offers no reset, so a second listing would still see the first one's store; whether an inactive or another adapter's configuration counts is `DataHubConfigurationUsage::hasActiveOfType()`'s decision, not this bundle's.
- Live: `usage.data_importer` reads `true` on the demo install, and the provider resolves and is tagged in the container. The round trip was also run against the demo's booted kernel: a seeded active import is read back with the right type and turns the adapter `true`, and is gone after cleanup.
- PHPStan level 6 clean on `src/Telemetry`. php-cs-fixer not run locally; CI validates it.

## Requires

- `pimcore/pimcore: ^2026.3` — the `usage.*` extension point (`BundleUsageProviderInterface`) is on core `2026.x` (commit d6491530d7) but not yet tagged.
- `pimcore/data-hub: ^2026.3` — `DataHubConfigurationUsage` landed in pimcore/data-hub#1138 on `2026.x`, not yet tagged.

Both are the same bumps the four Data Hub satellite bundles already carry on their `2026.x`.

Refs pimcore/product-management#1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
