### PR TITLE
[Spike] Map between stored and form addressing of a configuration

### DIFF
--- a/src/Settings/ConfigurationPathMapper.php
+++ b/src/Settings/ConfigurationPathMapper.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Settings;
+
+use function array_is_list;
+use function array_key_exists;
+use function array_shift;
+use function array_slice;
+use function array_unshift;
+use function count;
+use function ctype_digit;
+use function explode;
+use function implode;
+use function in_array;
+use function is_array;
+use function is_string;
+
+/**
+ * Translates between the two addressings of one configuration: the STORED document, and the
+ * form the Studio editor binds to. `transformBackendToForm()` is not shape-preserving, so a
+ * dotted address into the stored document does not name the same field in the form.
+ *
+ * Two rules cover every divergence; everything else is the same path on both sides.
+ *
+ * @internal
+ */
+final readonly class ConfigurationPathMapper
+{
+    /** the general.* keys the form lifts to the top level */
+    private const array FLATTENED = ['active', 'description', 'group', 'name'];
+
+    private const string GENERAL = 'general';
+
+    private const string MAPPING = 'mappingConfig';
+
+    /**
+     * Stored address to form address, or null when the form has no field for it - an
+     * address under a mapping item this configuration does not carry, most of all.
+     *
+     * @param array<string, mixed> $configuration the stored document the address is read against
+     */
+    public function toFormPath(string $storedPath, array $configuration): ?string
+    {
+        $segments = $this->segments($storedPath);
+        if ($segments === []) {
+            return null;
+        }
+
+        if ($segments[0] === self::GENERAL) {
+            return $this->liftGeneral($segments);
+        }
+
+        if ($segments[0] === self::MAPPING && count($segments) > 1) {
+            $index = $this->indexOfMappingId($segments[1], $configuration);
+
+            return $index === null ? null : $this->replaceSecond($segments, (string) $index);
+        }
+
+        return $storedPath;
+    }
+
+    /**
+     * Form address to stored address, or null when nothing in the stored document answers
+     * to it - a mapping row the form holds at an index the document does not have.
+     *
+     * @param array<string, mixed> $configuration
+     */
+    public function toStoredPath(string $formPath, array $configuration): ?string
+    {
+        $segments = $this->segments($formPath);
+        if ($segments === []) {
+            return null;
+        }
+
+        if (in_array($segments[0], self::FLATTENED, true)) {
+            array_unshift($segments, self::GENERAL);
+
+            return implode('.', $segments);
+        }
+
+        if ($segments[0] === self::MAPPING && count($segments) > 1) {
+            $id = $this->mappingIdAtIndex($segments[1], $configuration);
+
+            return $id === null ? null : $this->replaceSecond($segments, $id);
+        }
+
+        return $formPath;
+    }
+
+    /**
+     * The mapping items keyed by their `mappingId`, in document order. An item without one -
+     * a configuration never saved through Studio, which is where the id is minted - is
+     * skipped rather than given a positional key, so a caller can tell the difference.
+     *
+     * @param array<string, mixed> $configuration
+     *
+     * @return array<string, int> mappingId => index in the stored list
+     */
+    public function mappingIndex(array $configuration): array
+    {
+        $items = $configuration[self::MAPPING] ?? null;
+        if (!is_array($items) || !array_is_list($items)) {
+            return [];
+        }
+
+        $index = [];
+        foreach ($items as $position => $item) {
+            $id = is_array($item) ? ($item['mappingId'] ?? null) : null;
+            if (is_string($id) && $id !== '') {
+                $index[$id] = $position;
+            }
+        }
+
+        return $index;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function indexOfMappingId(string $id, array $configuration): ?int
+    {
+        $index = $this->mappingIndex($configuration);
+
+        return array_key_exists($id, $index) ? $index[$id] : null;
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function mappingIdAtIndex(string $position, array $configuration): ?string
+    {
+        if (!ctype_digit($position)) {
+            return null;
+        }
+
+        foreach ($this->mappingIndex($configuration) as $id => $at) {
+            if ($at === (int) $position) {
+                return $id;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * `general.name` is the exception: the form binds the configuration's name, which the
+     * detail view supplies separately, so the address still lands on a real field.
+     *
+     * @param list<string> $segments
+     */
+    private function liftGeneral(array $segments): ?string
+    {
+        $lifted = array_slice($segments, 1);
+        if ($lifted === [] || !in_array($lifted[0], self::FLATTENED, true)) {
+            return null;
+        }
+
+        return implode('.', $lifted);
+    }
+
+    /**
+     * @param list<string> $segments
+     */
+    private function replaceSecond(array $segments, string $replacement): string
+    {
+        $head = array_shift($segments);
+        array_shift($segments);
+        array_unshift($segments, $head, $replacement);
+
+        return implode('.', $segments);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function segments(string $path): array
+    {
+        return $path === '' ? [] : explode('.', $path);
+    }
+}

--- a/tests/unit/Settings/ConfigurationPathMapperTest.php
+++ b/tests/unit/Settings/ConfigurationPathMapperTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This source file is available under the terms of the
+ * Pimcore Open Core License (POCL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (https://www.pimcore.com)
+ *  @license    Pimcore Open Core License (POCL)
+ */
+
+namespace Pimcore\Bundle\DataImporterBundle\Tests\unit\Settings;
+
+use Codeception\Test\Unit;
+use Pimcore\Bundle\DataImporterBundle\Settings\ConfigurationPathMapper;
+
+class ConfigurationPathMapperTest extends Unit
+{
+    private const string ID_PRICE = '4ac0f1d2-0000-4000-8000-00000000002f';
+
+    private const string ID_VIN = '1a44b7e6-0000-4000-8000-000000000008';
+
+    private ConfigurationPathMapper $mapper;
+
+    protected function _before(): void
+    {
+        $this->mapper = new ConfigurationPathMapper();
+    }
+
+    public function testGeneralKeysAreLiftedToTheFormRoot(): void
+    {
+        foreach (['active', 'description', 'group', 'name'] as $key) {
+            static::assertSame($key, $this->mapper->toFormPath('general.' . $key, $this->configuration()));
+            static::assertSame('general.' . $key, $this->mapper->toStoredPath($key, $this->configuration()));
+        }
+    }
+
+    public function testGeneralKeyTheFormDoesNotBindHasNoFormPath(): void
+    {
+        // written by the API, never rendered - a review must not offer it as a field
+        static::assertNull($this->mapper->toFormPath('general.modificationDate', $this->configuration()));
+        static::assertNull($this->mapper->toFormPath('general.type', $this->configuration()));
+    }
+
+    public function testSectionsWithTheSameShapeMapToThemselves(): void
+    {
+        $paths = [
+            'loaderConfig.settings.path',
+            'interpreterConfig.settings.delimiter',
+            'resolverConfig.loadingStrategy.settings.attributeName',
+            'processingConfig.cleanupStrategy',
+            'executionConfig.cronDefinition',
+        ];
+
+        foreach ($paths as $path) {
+            static::assertSame($path, $this->mapper->toFormPath($path, $this->configuration()));
+            static::assertSame($path, $this->mapper->toStoredPath($path, $this->configuration()));
+        }
+    }
+
+    public function testMappingItemsAreAddressedByIdWhenStoredAndByIndexInTheForm(): void
+    {
+        static::assertSame(
+            'mappingConfig.1.dataTarget.settings.fieldName',
+            $this->mapper->toFormPath(
+                'mappingConfig.' . self::ID_PRICE . '.dataTarget.settings.fieldName',
+                $this->configuration()
+            )
+        );
+
+        static::assertSame(
+            'mappingConfig.' . self::ID_PRICE . '.dataTarget.settings.fieldName',
+            $this->mapper->toStoredPath('mappingConfig.1.dataTarget.settings.fieldName', $this->configuration())
+        );
+    }
+
+    public function testWholeMappingItemRoundTrips(): void
+    {
+        static::assertSame('mappingConfig.0', $this->mapper->toFormPath('mappingConfig.' . self::ID_VIN, $this->configuration()));
+        static::assertSame('mappingConfig.' . self::ID_VIN, $this->mapper->toStoredPath('mappingConfig.0', $this->configuration()));
+    }
+
+    /**
+     * The asymmetry a review has to handle: a proposal that ADDS a mapping names an id the
+     * current configuration has no row for, so there is no index to annotate. The surface has
+     * to insert the row before it can point at it.
+     */
+    public function testAddedMappingItemHasNoFormPathYet(): void
+    {
+        static::assertNull(
+            $this->mapper->toFormPath('mappingConfig.b1180000-0000-4000-8000-00000000009a.dataTarget', $this->configuration())
+        );
+    }
+
+    public function testIndexBeyondTheStoredListHasNoStoredPath(): void
+    {
+        static::assertNull($this->mapper->toStoredPath('mappingConfig.9.dataTarget', $this->configuration()));
+        static::assertNull($this->mapper->toStoredPath('mappingConfig.notAnIndex.dataTarget', $this->configuration()));
+    }
+
+    /**
+     * `mappingId` is minted in the Studio form, so a configuration written before it - or by
+     * the console - carries none. Those rows are not addressable by id at all, which is why
+     * they are skipped rather than given a positional key.
+     */
+    public function testItemsWithoutAMappingIdAreNotAddressable(): void
+    {
+        $legacy = ['mappingConfig' => [['dataSourceIndex' => 'vin'], ['dataSourceIndex' => 'price']]];
+
+        static::assertSame([], $this->mapper->mappingIndex($legacy));
+        static::assertNull($this->mapper->toStoredPath('mappingConfig.0.dataTarget', $legacy));
+    }
+
+    public function testMappingIndexSkipsOnlyTheItemsWithoutAnId(): void
+    {
+        $mixed = ['mappingConfig' => [
+            ['dataSourceIndex' => 'legacy'],
+            ['mappingId' => self::ID_VIN, 'dataSourceIndex' => 'vin'],
+        ]];
+
+        static::assertSame([self::ID_VIN => 1], $this->mapper->mappingIndex($mixed));
+    }
+
+    public function testEmptyPathHasNoCounterpart(): void
+    {
+        static::assertNull($this->mapper->toFormPath('', $this->configuration()));
+        static::assertNull($this->mapper->toStoredPath('', $this->configuration()));
+    }
+
+    public function testMappingConfigItselfIsNotAnItemAddress(): void
+    {
+        static::assertSame('mappingConfig', $this->mapper->toFormPath('mappingConfig', $this->configuration()));
+        static::assertSame('mappingConfig', $this->mapper->toStoredPath('mappingConfig', $this->configuration()));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function configuration(): array
+    {
+        return [
+            'general' => [
+                'name' => 'csv-car-import',
+                'active' => true,
+                'description' => 'Nightly vehicle master import',
+                'group' => 'Vehicle data',
+                'type' => 'dataImporterDataObject',
+                'modificationDate' => 1788000000,
+            ],
+            'mappingConfig' => [
+                ['mappingId' => self::ID_VIN, 'dataSourceIndex' => 'vin'],
+                ['mappingId' => self::ID_PRICE, 'dataSourceIndex' => 'list_price'],
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
**Spike — for review of the approach, not for merge as it stands.** Nothing consumes `ConfigurationPathMapper` yet; it exists to settle a question before a review/diff surface is built on top of the configuration editor.

`transformBackendToForm()` is not shape-preserving, so a dotted address into the stored configuration does not name the same field in the form. Two rules cover every divergence:

1. `general.active|description|group|name` are lifted to the form root.
2. Mapping items are addressed by `mappingId` in the stored document and by list index in the form.

Everything else is the same path on both sides.

The tests document three findings that matter for anything diffing a configuration:

- **The mapping is config-dependent, not a string rewrite.** Resolving an item needs the document.
- **It is asymmetric.** An address naming a mapping item the configuration does not carry — an item some other version adds — has no form path at all, because there is no row to point at.
- **`mappingId` is minted in the Studio form**, so a configuration written before it, or by the console, carries none. Those rows are skipped rather than given a positional key, so a caller can tell the difference.

## Gates

| Gate | Result |
|---|---|
| PHPStan (level 5) | 0 errors |
| php-cs-fixer | 0 files to fix |
| Codeception unit | 11 tests, 34 assertions, green |

🤖 Generated with [Claude Code](https://claude.com/claude-code)